### PR TITLE
Boost shared_ptr everywhere

### DIFF
--- a/gtdynamics/factors/PoseFactor.h
+++ b/gtdynamics/factors/PoseFactor.h
@@ -40,7 +40,7 @@ class PoseFactor
       gtsam::NoiseModelFactor3<gtsam::Pose3, gtsam::Pose3, JointCoordinate>;
   enum { N = JointTyped::N };
 
-  std::shared_ptr<const JointTyped> joint_;
+  boost::shared_ptr<const JointTyped> joint_;
 
  public:
   /**
@@ -51,7 +51,7 @@ class PoseFactor
              const gtsam::noiseModel::Base::shared_ptr &cost_model,
              JointConstSharedPtr joint)
       : Base(cost_model, wTp_key, wTc_key, q_key),
-        joint_(std::static_pointer_cast<const JointTyped>(joint)) {}
+        joint_(boost::static_pointer_cast<const JointTyped>(joint)) {}
 
   virtual ~PoseFactor() {}
 

--- a/gtdynamics/factors/TorqueFactor.h
+++ b/gtdynamics/factors/TorqueFactor.h
@@ -36,7 +36,7 @@ class TorqueFactor
   using JointTorque = typename JointTyped::JointTorque;
   using This = TorqueFactor;
   using Base = gtsam::NoiseModelFactor2<gtsam::Vector6, JointTorque>;
-  using MyJointConstSharedPtr = std::shared_ptr<const JointTyped>;
+  using MyJointConstSharedPtr = boost::shared_ptr<const JointTyped>;
   MyJointConstSharedPtr joint_;
 
  public:

--- a/gtdynamics/factors/TwistAccelFactor.h
+++ b/gtdynamics/factors/TwistAccelFactor.h
@@ -42,7 +42,7 @@ class TwistAccelFactor
   using Base = gtsam::NoiseModelFactor6<gtsam::Vector6, gtsam::Vector6,
                                         gtsam::Vector6, JointCoordinate,
                                         JointVelocity, JointAcceleration>;
-  using JointTypedConstSharedPtr = std::shared_ptr<const JointTyped>;
+  using JointTypedConstSharedPtr = boost::shared_ptr<const JointTyped>;
   JointTypedConstSharedPtr joint_;
 
  public:

--- a/gtdynamics/factors/TwistFactor.h
+++ b/gtdynamics/factors/TwistFactor.h
@@ -76,7 +76,7 @@ class TwistFactor
       boost::optional<gtsam::Matrix &> H_q = boost::none,
       boost::optional<gtsam::Matrix &> H_qVel = boost::none) const override {
     auto error =
-        std::static_pointer_cast<const JointTyped>(joint_)->transformTwistTo(
+        boost::static_pointer_cast<const JointTyped>(joint_)->transformTwistTo(
             joint_->childLink(), q, qVel, twist_p, H_q, H_qVel, H_twist_p) -
         twist_c;
 

--- a/gtdynamics/factors/WrenchEquivalenceFactor.h
+++ b/gtdynamics/factors/WrenchEquivalenceFactor.h
@@ -39,7 +39,7 @@ class WrenchEquivalenceFactor
   using Base =
       gtsam::NoiseModelFactor3<gtsam::Vector6, gtsam::Vector6, JointCoordinate>;
 
-  using JointTypedConstSharedPtr = std::shared_ptr<const JointTyped>;
+  using JointTypedConstSharedPtr = boost::shared_ptr<const JointTyped>;
   JointTypedConstSharedPtr joint_;
 
  public:

--- a/gtdynamics/universal_robot/JointTyped.cpp
+++ b/gtdynamics/universal_robot/JointTyped.cpp
@@ -54,7 +54,7 @@ gtsam::NonlinearFactorGraph JointTyped::aFactors(
       TwistAccelKey(parent_link_->getID(), t),
       TwistAccelKey(child_link_->getID(), t), JointAngleKey(getID(), t),
       JointVelKey(getID(), t), JointAccelKey(getID(), t), opt.a_cost_model,
-      std::static_pointer_cast<const This>(getConstSharedPtr()));
+      boost::static_pointer_cast<const This>(getConstSharedPtr()));
 
   return graph;
 }
@@ -67,11 +67,11 @@ gtsam::NonlinearFactorGraph JointTyped::dynamicsFactors(
       WrenchKey(parent_link_->getID(), getID(), t),
       WrenchKey(child_link_->getID(), getID(), t), JointAngleKey(getID(), t),
       opt.f_cost_model,
-      std::static_pointer_cast<const This>(getConstSharedPtr()));
+      boost::static_pointer_cast<const This>(getConstSharedPtr()));
   graph.emplace_shared<TorqueFactor>(
       WrenchKey(child_link_->getID(), getID(), t), TorqueKey(getID(), t),
       opt.t_cost_model,
-      std::static_pointer_cast<const This>(getConstSharedPtr()));
+      boost::static_pointer_cast<const This>(getConstSharedPtr()));
   if (planar_axis)
     graph.emplace_shared<WrenchPlanarFactor>(
         WrenchKey(child_link_->getID(), getID(), t), opt.planar_cost_model,

--- a/gtdynamics/universal_robot/Link.h
+++ b/gtdynamics/universal_robot/Link.h
@@ -23,6 +23,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/enable_shared_from_this.hpp>
 #include <memory>
 #include <sdf/sdf.hh>
 #include <string>
@@ -59,7 +60,7 @@ inline DynamicsSymbol WrenchKey(int i, int j, int t) {
 /**
  * @class Base class for links taking different format of parameters.
  */
-class Link : public std::enable_shared_from_this<Link> {
+class Link : public boost::enable_shared_from_this<Link> {
  private:
   std::string name_;
 
@@ -149,13 +150,7 @@ class Link : public std::enable_shared_from_this<Link> {
 
   /// remove the joint
   void removeJoint(JointSharedPtr joint) {
-    for (auto joint_it = joints_.begin(); joint_it != joints_.end();
-         joint_it++) {
-      if ((*joint_it) == joint) {
-        joints_.erase(joint_it);
-        break;
-      }
-    }
+    joints_.erase(std::remove(joints_.begin(), joints_.end(), joint));
   }
 
   /// set ID for the link
@@ -178,10 +173,10 @@ class Link : public std::enable_shared_from_this<Link> {
   /// transform from link to world frame
   const gtsam::Pose3 &wTl() const { return wTl_; }
 
-  /// transfrom from link com frame to link frame
+  /// transform from link CoM frame to link frame
   const gtsam::Pose3 &lTcom() const { return lTcom_; }
 
-  /// transform from link com frame to world frame
+  /// transform from link CoM frame to world frame
   inline const gtsam::Pose3 wTcom() const { return wTl() * lTcom(); }
 
   /// the fixed pose of the link
@@ -200,7 +195,7 @@ class Link : public std::enable_shared_from_this<Link> {
   void unfix() { is_fixed_ = false; }
 
   /// return all joints of the link
-  const std::vector<JointSharedPtr> &getJoints(void) const { return joints_; }
+  const std::vector<JointSharedPtr> &getJoints() const { return joints_; }
 
   /// Return link name.
   std::string name() const { return name_; }
@@ -221,6 +216,15 @@ class Link : public std::enable_shared_from_this<Link> {
     gmm.push_back(gtsam::I_3x3 * mass_);
     return gtsam::diag(gmm);
   }
+
+  /// Print to ostream
+  friend std::ostream &operator<<(std::ostream &os, const Link &l) {
+    os << l.name();
+    return os;
+  }
+
+  /// Helper print function
+  void print() const { std::cout << *this; }
 
   /**
    * @fn Return pose factors in the dynamics graph.

--- a/gtdynamics/universal_robot/Robot.cpp
+++ b/gtdynamics/universal_robot/Robot.cpp
@@ -168,7 +168,7 @@ FKResults Robot::forwardKinematics(
     q.pop();
     for (JointSharedPtr joint : link1->getJoints()) {
       ScrewJointBaseSharedPtr joint_ptr =
-          std::dynamic_pointer_cast<ScrewJointBase>(joint);
+          boost::dynamic_pointer_cast<ScrewJointBase>(joint);
       LinkSharedPtr link2 = joint_ptr->otherLink(link1);
       // calculate the pose and twist of link2
       double joint_angle = joint_angles.at(joint_ptr->name());

--- a/gtdynamics/universal_robot/Robot.h
+++ b/gtdynamics/universal_robot/Robot.h
@@ -92,7 +92,7 @@ class Robot {
   /// Return number of joints.
   int numJoints() const;
 
-  // print links and joints of the robot, for debug purposes
+  /// Print links and joints of the robot, for debug purposes
   void print() const;
 
   /**

--- a/gtdynamics/universal_robot/RobotTypes.h
+++ b/gtdynamics/universal_robot/RobotTypes.h
@@ -16,15 +16,16 @@
 #include <gtsam/base/Vector.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/Values.h>
+#include <boost/shared_ptr.hpp>
 
 #include <memory>
 #include <string>
 
 #define LINK_TYPEDEF_CLASS_POINTER(Class)                     \
   class Class;                                                \
-  typedef std::shared_ptr<Class> Class##SharedPtr;            \
-  typedef std::shared_ptr<const Class> Class##ConstSharedPtr; \
-  typedef std::weak_ptr<Class> Class##WeakPtr
+  typedef boost::shared_ptr<Class> Class##SharedPtr;            \
+  typedef boost::shared_ptr<const Class> Class##ConstSharedPtr; \
+  typedef boost::weak_ptr<Class> Class##WeakPtr
 
 namespace gtdynamics {
 

--- a/gtdynamics/universal_robot/sdf.cpp
+++ b/gtdynamics/universal_robot/sdf.cpp
@@ -75,7 +75,7 @@ static LinkJointPair ExtractRobotFromSdf(const sdf::Model &sdf) {
   // objects without parents or children.
   LinkMap name_to_link;
   for (uint i = 0; i < sdf.LinkCount(); i++) {
-    LinkSharedPtr link = std::make_shared<Link>(*sdf.LinkByIndex(i));
+    LinkSharedPtr link = boost::make_shared<Link>(*sdf.LinkByIndex(i));
     link->setID(i);
     name_to_link.emplace(link->name(), link);
   }
@@ -110,17 +110,17 @@ static LinkJointPair ExtractRobotFromSdf(const sdf::Model &sdf) {
     const gtsam::Vector3 axis = GetSdfAxis(sdf_joint);
     switch (sdf_joint.Type()) {
       case sdf::JointType::PRISMATIC:
-        joint = std::make_shared<PrismaticJoint>(name, wTj, parent_link,
-                                                 child_link, parameters, axis);
+        joint = boost::make_shared<PrismaticJoint>(
+            name, wTj, parent_link, child_link, parameters, axis);
         break;
       case sdf::JointType::REVOLUTE:
-        joint = std::make_shared<RevoluteJoint>(name, wTj, parent_link,
-                                                child_link, parameters, axis);
+        joint = boost::make_shared<RevoluteJoint>(name, wTj, parent_link,
+                                                  child_link, parameters, axis);
         break;
       case sdf::JointType::SCREW:
-        joint = std::make_shared<ScrewJoint>(name, wTj, parent_link, child_link,
-                                             parameters, axis,
-                                             sdf_joint.ThreadPitch());
+        joint = boost::make_shared<ScrewJoint>(name, wTj, parent_link,
+                                               child_link, parameters, axis,
+                                               sdf_joint.ThreadPitch());
         break;
       default:
         throw std::runtime_error("Joint type for [" + name +

--- a/gtdynamics/utils/JsonSaver.h
+++ b/gtdynamics/utils/JsonSaver.h
@@ -201,7 +201,7 @@ class JsonSaver {
     std::stringstream ss;
     if (const TorqueFactor* f = dynamic_cast<const TorqueFactor*>(&(*factor))) {
       auto joint = f->getJoint();
-      ss << GetVector(std::static_pointer_cast<const ScrewJointBase>(joint)
+      ss << GetVector(boost::static_pointer_cast<const ScrewJointBase>(joint)
                           ->screwAxis(joint->childLink())
                           .transpose());
     } else if (const gtsam::PriorFactor<gtsam::Vector3>* f =

--- a/tests/testLink.cpp
+++ b/tests/testLink.cpp
@@ -35,7 +35,7 @@ TEST(Link, params_constructor) {
   parameters.wTl = gtsam::Pose3();
   parameters.lTcom = gtsam::Pose3(gtsam::Rot3(), gtsam::Point3(0, 0, 1));
 
-  LinkSharedPtr l1 = std::make_shared<Link>(parameters);
+  LinkSharedPtr l1 = boost::make_shared<Link>(parameters);
 
   // name
   EXPECT(assert_equal("l1", l1->name()));

--- a/tests/testPoseFactor.cpp
+++ b/tests/testPoseFactor.cpp
@@ -50,8 +50,8 @@ ScrewJointBaseConstSharedPtr make_joint(gtsam::Pose3 cMp,
   link2_params = link1_params;
   link2_params.wTl = cMp.inverse();
 
-  LinkSharedPtr l1 = std::make_shared<Link>(Link(link1_params));
-  LinkSharedPtr l2 = std::make_shared<Link>(Link(link2_params));
+  LinkSharedPtr l1 = boost::make_shared<Link>(Link(link1_params));
+  LinkSharedPtr l2 = boost::make_shared<Link>(Link(link2_params));
 
   // create joint
   ScrewJointBase::Parameters joint_params;
@@ -63,7 +63,7 @@ ScrewJointBaseConstSharedPtr make_joint(gtsam::Pose3 cMp,
   gtsam::Pose3 jTccom = wTj.inverse() * l2->wTcom();
   gtsam::Vector6 jScrewAxis = jTccom.AdjointMap() * cScrewAxis;
 
-  return std::make_shared<const ScrewJointBase>(ScrewJointBase(
+  return boost::make_shared<const ScrewJointBase>(ScrewJointBase(
       "j1", wTj, l1, l2, joint_params, jScrewAxis.head<3>(), jScrewAxis));
 }
 
@@ -135,7 +135,7 @@ TEST(PoseFactor, breaking_rr) {
   double joint_angle = M_PI / 4;
 
   auto l2 = my_robot.getLinkByName("l2");
-  auto j1 = std::dynamic_pointer_cast<gtdynamics::ScrewJointBase>(
+  auto j1 = boost::dynamic_pointer_cast<gtdynamics::ScrewJointBase>(
       my_robot.getJointByName("j1"));
   gtsam::Vector6 screw_axis =
       (gtsam::Vector(6) << 1, 0, 0, 0, -1, 0).finished();

--- a/tests/testPrismaticJoint.cpp
+++ b/tests/testPrismaticJoint.cpp
@@ -30,8 +30,8 @@ using gtsam::assert_equal, gtsam::Pose3, gtsam::Point3, gtsam::Rot3;
 TEST(Joint, params_constructor_prismatic) {
   auto simple_urdf =
       get_sdf(std::string(URDF_PATH) + "/test/simple_urdf_prismatic.urdf");
-  LinkSharedPtr l1 = std::make_shared<Link>(*simple_urdf.LinkByName("l1"));
-  LinkSharedPtr l2 = std::make_shared<Link>(*simple_urdf.LinkByName("l2"));
+  LinkSharedPtr l1 = boost::make_shared<Link>(*simple_urdf.LinkByName("l1"));
+  LinkSharedPtr l2 = boost::make_shared<Link>(*simple_urdf.LinkByName("l2"));
 
   ScrewJointBase::Parameters parameters;
   parameters.effort_type = Joint::EffortType::Actuated;
@@ -41,7 +41,7 @@ TEST(Joint, params_constructor_prismatic) {
 
   const gtsam::Vector3 j1_axis = (gtsam::Vector(3) << 0, 0, 1).finished();
 
-  PrismaticJointSharedPtr j1 = std::make_shared<PrismaticJoint>(
+  PrismaticJointSharedPtr j1 = boost::make_shared<PrismaticJoint>(
       "j1", Pose3(Rot3::Rx(1.5707963268), Point3(0, 0, 2)), l1, l2, parameters,
       j1_axis);
 

--- a/tests/testRevoluteJoint.cpp
+++ b/tests/testRevoluteJoint.cpp
@@ -29,8 +29,8 @@ using gtsam::assert_equal, gtsam::Pose3, gtsam::Point3, gtsam::Rot3;
  */
 TEST(Joint, params_constructor) {
   auto simple_urdf = get_sdf(std::string(URDF_PATH) + "/test/simple_urdf.urdf");
-  LinkSharedPtr l1 = std::make_shared<Link>(*simple_urdf.LinkByName("l1"));
-  LinkSharedPtr l2 = std::make_shared<Link>(*simple_urdf.LinkByName("l2"));
+  LinkSharedPtr l1 = boost::make_shared<Link>(*simple_urdf.LinkByName("l1"));
+  LinkSharedPtr l2 = boost::make_shared<Link>(*simple_urdf.LinkByName("l2"));
 
   ScrewJointBase::Parameters parameters;
   parameters.effort_type = Joint::EffortType::Actuated;
@@ -40,7 +40,7 @@ TEST(Joint, params_constructor) {
 
   const gtsam::Vector3 axis = (gtsam::Vector(3) << 1, 0, 0).finished();
 
-  auto j1 = std::make_shared<RevoluteJoint>(
+  auto j1 = boost::make_shared<RevoluteJoint>(
       "j1", Pose3(Rot3(), Point3(0, 0, 2)), l1, l2, parameters, axis);
 
   // name

--- a/tests/testScrewJoint.cpp
+++ b/tests/testScrewJoint.cpp
@@ -30,8 +30,8 @@ using gtsam::assert_equal, gtsam::Pose3, gtsam::Point3, gtsam::Rot3;
  */
 TEST(Joint, params_constructor) {
   auto simple_urdf = get_sdf(std::string(URDF_PATH) + "/test/simple_urdf.urdf");
-  LinkSharedPtr l1 = std::make_shared<Link>(*simple_urdf.LinkByName("l1"));
-  LinkSharedPtr l2 = std::make_shared<Link>(*simple_urdf.LinkByName("l2"));
+  LinkSharedPtr l1 = boost::make_shared<Link>(*simple_urdf.LinkByName("l1"));
+  LinkSharedPtr l2 = boost::make_shared<Link>(*simple_urdf.LinkByName("l2"));
 
   ScrewJointBase::Parameters parameters;
   parameters.effort_type = Joint::EffortType::Actuated;
@@ -40,7 +40,7 @@ TEST(Joint, params_constructor) {
   parameters.scalar_limits.value_limit_threshold = 0;
 
   ScrewJointSharedPtr j1 =
-      std::make_shared<ScrewJoint>("j1", Pose3(Rot3(), Point3(0, 0, 2)), l1, l2,
+      boost::make_shared<ScrewJoint>("j1", Pose3(Rot3(), Point3(0, 0, 2)), l1, l2,
                                    parameters, gtsam::Vector3(1, 0, 0), 0.5);
   j1->setID(123);
 

--- a/tests/testSdf.cpp
+++ b/tests/testSdf.cpp
@@ -110,8 +110,8 @@ TEST(Link, urdf_constructor_link) {
   auto simple_urdf = get_sdf(std::string(URDF_PATH) + "/test/simple_urdf.urdf");
 
   // Initialize Robot instance using urdf::ModelInterfacePtr.
-  LinkSharedPtr l1 = std::make_shared<Link>(*simple_urdf.LinkByName("l1"));
-  LinkSharedPtr l2 = std::make_shared<Link>(*simple_urdf.LinkByName("l2"));
+  LinkSharedPtr l1 = boost::make_shared<Link>(*simple_urdf.LinkByName("l1"));
+  LinkSharedPtr l2 = boost::make_shared<Link>(*simple_urdf.LinkByName("l2"));
   ScrewJointBase::Parameters j1_parameters;
   j1_parameters.effort_type = Joint::EffortType::Actuated;
 
@@ -119,7 +119,7 @@ TEST(Link, urdf_constructor_link) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
   // Test constructor.
-  RevoluteJointSharedPtr j1 = std::make_shared<RevoluteJoint>(
+  RevoluteJointSharedPtr j1 = boost::make_shared<RevoluteJoint>(
       "j1", wTj, l1, l2, j1_parameters, j1_axis);
 
   // get shared ptr
@@ -172,8 +172,8 @@ TEST(Link, urdf_constructor_link) {
 TEST(Joint, urdf_constructor_revolute) {
   auto simple_urdf = get_sdf(std::string(URDF_PATH) + "/test/simple_urdf.urdf");
 
-  LinkSharedPtr l1 = std::make_shared<Link>(*simple_urdf.LinkByName("l1"));
-  LinkSharedPtr l2 = std::make_shared<Link>(*simple_urdf.LinkByName("l2"));
+  LinkSharedPtr l1 = boost::make_shared<Link>(*simple_urdf.LinkByName("l1"));
+  LinkSharedPtr l2 = boost::make_shared<Link>(*simple_urdf.LinkByName("l2"));
 
   auto j1_parameters = ParametersFromSdfJoint(*simple_urdf.JointByName("j1"));
   j1_parameters.effort_type = Joint::EffortType::Actuated;
@@ -182,7 +182,7 @@ TEST(Joint, urdf_constructor_revolute) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
   // Test constructor.
-  auto j1 = std::make_shared<RevoluteJoint>("j1", j1_wTj, l1, l2, j1_parameters,
+  auto j1 = boost::make_shared<RevoluteJoint>("j1", j1_wTj, l1, l2, j1_parameters,
                                             j1_axis);
 
   // get shared ptr
@@ -251,9 +251,9 @@ TEST(Joint, sdf_constructor_revolute) {
   auto model =
       get_sdf(std::string(SDF_PATH) + "/test/simple_rr.sdf", "simple_rr_sdf");
 
-  LinkSharedPtr l0 = std::make_shared<Link>(*model.LinkByName("link_0"));
-  LinkSharedPtr l1 = std::make_shared<Link>(*model.LinkByName("link_1"));
-  LinkSharedPtr l2 = std::make_shared<Link>(*model.LinkByName("link_2"));
+  LinkSharedPtr l0 = boost::make_shared<Link>(*model.LinkByName("link_0"));
+  LinkSharedPtr l1 = boost::make_shared<Link>(*model.LinkByName("link_1"));
+  LinkSharedPtr l2 = boost::make_shared<Link>(*model.LinkByName("link_2"));
 
   Pose3 j1_wTj = GetJointFrame(*model.JointByName("joint_1"), l0, l1);
   const gtsam::Vector3 j1_axis = GetSdfAxis(*model.JointByName("joint_1"));
@@ -261,7 +261,7 @@ TEST(Joint, sdf_constructor_revolute) {
   // constructor for j1
   ScrewJointBase::Parameters j1_parameters;
   j1_parameters.effort_type = Joint::EffortType::Actuated;
-  auto j1 = std::make_shared<RevoluteJoint>("joint_1", j1_wTj, l0, l1,
+  auto j1 = boost::make_shared<RevoluteJoint>("joint_1", j1_wTj, l0, l1,
                                             j1_parameters, j1_axis);
 
   // check screw axis
@@ -287,7 +287,7 @@ TEST(Joint, sdf_constructor_revolute) {
   Pose3 j2_wTj = GetJointFrame(*model.JointByName("joint_2"), l1, l2);
   const gtsam::Vector3 j2_axis = GetSdfAxis(*model.JointByName("joint_2"));
 
-  auto j2 = std::make_shared<RevoluteJoint>("joint_2", j2_wTj, l1, l2,
+  auto j2 = boost::make_shared<RevoluteJoint>("joint_2", j2_wTj, l1, l2,
                                             j2_parameters, j2_axis);
 
   // check screw axis
@@ -313,15 +313,15 @@ TEST(Joint, sdf_constructor_revolute) {
 TEST(Joint, limit_params) {
   // Check revolute joint limits parsed correctly for first test robot.
   auto model = get_sdf(std::string(SDF_PATH) + "/test/four_bar_linkage.sdf");
-  LinkSharedPtr l1 = std::make_shared<Link>(*model.LinkByName("l1"));
-  LinkSharedPtr l2 = std::make_shared<Link>(*model.LinkByName("l2"));
+  LinkSharedPtr l1 = boost::make_shared<Link>(*model.LinkByName("l1"));
+  LinkSharedPtr l2 = boost::make_shared<Link>(*model.LinkByName("l2"));
   auto j1_parameters = ParametersFromSdfJoint(*model.JointByName("j1"));
   j1_parameters.effort_type = Joint::EffortType::Actuated;
 
   Pose3 j1_wTj = GetJointFrame(*model.JointByName("j1"), l1, l2);
   const gtsam::Vector3 j1_axis = GetSdfAxis(*model.JointByName("j1"));
 
-  auto j1 = std::make_shared<RevoluteJoint>("j1", j1_wTj, l1, l2, j1_parameters,
+  auto j1 = boost::make_shared<RevoluteJoint>("j1", j1_wTj, l1, l2, j1_parameters,
                                             j1_axis);
 
   EXPECT(assert_equal(-1.57, j1->parameters().scalar_limits.value_lower_limit));
@@ -332,8 +332,8 @@ TEST(Joint, limit_params) {
   // Check revolute joint limits parsed correctly for a robot with no limits.
   auto model2 =
       get_sdf(std::string(SDF_PATH) + "/test/simple_rr.sdf", "simple_rr_sdf");
-  LinkSharedPtr link_0 = std::make_shared<Link>(*model2.LinkByName("link_0"));
-  LinkSharedPtr link_1 = std::make_shared<Link>(*model2.LinkByName("link_1"));
+  LinkSharedPtr link_0 = boost::make_shared<Link>(*model2.LinkByName("link_0"));
+  LinkSharedPtr link_1 = boost::make_shared<Link>(*model2.LinkByName("link_1"));
   auto joint_1_parameters =
       ParametersFromSdfJoint(*model2.JointByName("joint_1"));
   joint_1_parameters.effort_type = Joint::EffortType::Actuated;
@@ -343,7 +343,7 @@ TEST(Joint, limit_params) {
   const gtsam::Vector3 joint_1_axis =
       GetSdfAxis(*model2.JointByName("joint_1"));
 
-  auto joint_1 = std::make_shared<RevoluteJoint>(
+  auto joint_1 = boost::make_shared<RevoluteJoint>(
       "joint_1", joint_1_wTj, link_0, link_1, joint_1_parameters, joint_1_axis);
 
   EXPECT(assert_equal(-1e16,
@@ -362,8 +362,8 @@ TEST(Joint, urdf_constructor_prismatic) {
   auto simple_urdf =
       get_sdf(std::string(URDF_PATH) + "/test/simple_urdf_prismatic.urdf");
 
-  auto l1 = std::make_shared<Link>(*simple_urdf.LinkByName("l1"));
-  auto l2 = std::make_shared<Link>(*simple_urdf.LinkByName("l2"));
+  auto l1 = boost::make_shared<Link>(*simple_urdf.LinkByName("l1"));
+  auto l2 = boost::make_shared<Link>(*simple_urdf.LinkByName("l2"));
 
   auto joint1 = *simple_urdf.JointByName("j1");
 
@@ -375,7 +375,7 @@ TEST(Joint, urdf_constructor_prismatic) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
   // Test constructor.
-  auto j1 = std::make_shared<PrismaticJoint>("j1", wTj, l1, l2, j1_parameters,
+  auto j1 = boost::make_shared<PrismaticJoint>("j1", wTj, l1, l2, j1_parameters,
                                              j1_axis);
 
   // get shared ptr
@@ -445,8 +445,8 @@ TEST(Joint, sdf_constructor_screw) {
   auto model = get_sdf(std::string(SDF_PATH) + "/test/simple_screw_joint.sdf",
                        "simple_screw_joint_sdf");
 
-  LinkSharedPtr l0 = std::make_shared<Link>(*model.LinkByName("link_0"));
-  LinkSharedPtr l1 = std::make_shared<Link>(*model.LinkByName("link_1"));
+  LinkSharedPtr l0 = boost::make_shared<Link>(*model.LinkByName("link_0"));
+  LinkSharedPtr l1 = boost::make_shared<Link>(*model.LinkByName("link_1"));
 
   Pose3 wTj = GetJointFrame(*model.JointByName("joint_1"), l0, l1);
 
@@ -455,7 +455,7 @@ TEST(Joint, sdf_constructor_screw) {
   j1_parameters.effort_type = Joint::EffortType::Actuated;
   const gtsam::Vector3 j1_axis = GetSdfAxis(*model.JointByName("joint_1"));
 
-  ScrewJointSharedPtr j1 = std::make_shared<ScrewJoint>(
+  ScrewJointSharedPtr j1 = boost::make_shared<ScrewJoint>(
       "joint_1", wTj, l0, l1, j1_parameters, j1_axis,
       model.JointByName("joint_1")->ThreadPitch());
 
@@ -483,14 +483,14 @@ TEST(Robot, simple_urdf) {
   // Load urdf file into sdf::Model
   auto simple_urdf = get_sdf(std::string(URDF_PATH) + "/test/simple_urdf.urdf");
 
-  auto l1 = std::make_shared<Link>(*simple_urdf.LinkByName("l1"));
-  auto l2 = std::make_shared<Link>(*simple_urdf.LinkByName("l2"));
+  auto l1 = boost::make_shared<Link>(*simple_urdf.LinkByName("l1"));
+  auto l2 = boost::make_shared<Link>(*simple_urdf.LinkByName("l2"));
 
   auto j1_parameters = ParametersFromSdfJoint(*simple_urdf.JointByName("j1"));
   Pose3 wTj = GetJointFrame(*simple_urdf.JointByName("j1"), l1, l2);
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
-  RevoluteJointSharedPtr j1 = std::make_shared<RevoluteJoint>(
+  RevoluteJointSharedPtr j1 = boost::make_shared<RevoluteJoint>(
       "j1", wTj, l1, l2, j1_parameters, j1_axis);
 
   // Initialize Robot instance.

--- a/tests/testTorqueFactor.cpp
+++ b/tests/testTorqueFactor.cpp
@@ -51,8 +51,8 @@ ScrewJointBaseConstSharedPtr make_joint(Pose3 jMi, Vector6 cScrewAxis) {
   link2_params = link1_params;
   link2_params.wTl = jMi.inverse();
 
-  LinkSharedPtr l1 = std::make_shared<Link>(Link(link1_params));
-  LinkSharedPtr l2 = std::make_shared<Link>(Link(link2_params));
+  LinkSharedPtr l1 = boost::make_shared<Link>(Link(link1_params));
+  LinkSharedPtr l2 = boost::make_shared<Link>(Link(link2_params));
 
   // create joint
   ScrewJointBase::Parameters joint_params;
@@ -64,7 +64,7 @@ ScrewJointBaseConstSharedPtr make_joint(Pose3 jMi, Vector6 cScrewAxis) {
   Pose3 jTccom = wTj.inverse() * l2->wTcom();
   Vector6 jScrewAxis = jTccom.AdjointMap() * cScrewAxis;
 
-  return std::make_shared<const ScrewJointBase>(ScrewJointBase(
+  return boost::make_shared<const ScrewJointBase>(ScrewJointBase(
       "j1", wTj, l1, l2, joint_params, jScrewAxis.head<3>(), jScrewAxis));
 }
 

--- a/tests/testTwistAccelFactor.cpp
+++ b/tests/testTwistAccelFactor.cpp
@@ -54,8 +54,8 @@ ScrewJointBaseConstSharedPtr make_joint(gtsam::Pose3 cMp,
   link2_params = link1_params;
   link2_params.wTl = cMp.inverse();
 
-  LinkSharedPtr l1 = std::make_shared<Link>(Link(link1_params));
-  LinkSharedPtr l2 = std::make_shared<Link>(Link(link2_params));
+  LinkSharedPtr l1 = boost::make_shared<Link>(Link(link1_params));
+  LinkSharedPtr l2 = boost::make_shared<Link>(Link(link2_params));
 
   // create joint
   ScrewJointBase::Parameters joint_params;
@@ -67,7 +67,7 @@ ScrewJointBaseConstSharedPtr make_joint(gtsam::Pose3 cMp,
   gtsam::Pose3 jTccom = wTj.inverse() * l2->wTcom();
   gtsam::Vector6 jScrewAxis = jTccom.AdjointMap() * cScrewAxis;
 
-  return std::make_shared<const ScrewJointBase>(ScrewJointBase(
+  return boost::make_shared<const ScrewJointBase>(ScrewJointBase(
       "j1", wTj, l1, l2, joint_params, jScrewAxis.head<3>(), jScrewAxis));
 }
 

--- a/tests/testTwistFactor.cpp
+++ b/tests/testTwistFactor.cpp
@@ -50,8 +50,8 @@ ScrewJointBaseConstSharedPtr make_joint(gtsam::Pose3 cMp,
   link2_params = link1_params;
   link2_params.wTl = cMp.inverse();
 
-  LinkSharedPtr l1 = std::make_shared<Link>(Link(link1_params));
-  LinkSharedPtr l2 = std::make_shared<Link>(Link(link2_params));
+  LinkSharedPtr l1 = boost::make_shared<Link>(Link(link1_params));
+  LinkSharedPtr l2 = boost::make_shared<Link>(Link(link2_params));
 
   // create joint
   ScrewJointBase::Parameters joint_params;
@@ -63,7 +63,7 @@ ScrewJointBaseConstSharedPtr make_joint(gtsam::Pose3 cMp,
   gtsam::Pose3 jTccom = wTj.inverse() * l2->wTcom();
   gtsam::Vector6 jScrewAxis = jTccom.AdjointMap() * cScrewAxis;
 
-  return std::make_shared<const ScrewJointBase>(ScrewJointBase(
+  return boost::make_shared<const ScrewJointBase>(ScrewJointBase(
       "j1", wTj, l1, l2, joint_params, jScrewAxis.head<3>(), jScrewAxis));
 }
 

--- a/tests/testWrenchEquivalenceFactor.cpp
+++ b/tests/testWrenchEquivalenceFactor.cpp
@@ -55,8 +55,8 @@ ScrewJointBaseConstSharedPtr make_joint(Pose3 jMi, Vector6 cScrewAxis) {
   link2_params = link1_params;
   link2_params.wTl = jMi.inverse();
 
-  LinkSharedPtr l1 = std::make_shared<Link>(Link(link1_params));
-  LinkSharedPtr l2 = std::make_shared<Link>(Link(link2_params));
+  LinkSharedPtr l1 = boost::make_shared<Link>(Link(link1_params));
+  LinkSharedPtr l2 = boost::make_shared<Link>(Link(link2_params));
 
   // create joint
   ScrewJointBase::Parameters joint_params;
@@ -68,7 +68,7 @@ ScrewJointBaseConstSharedPtr make_joint(Pose3 jMi, Vector6 cScrewAxis) {
   Pose3 jTccom = wTj.inverse() * l2->wTcom();
   Vector6 jScrewAxis = jTccom.AdjointMap() * cScrewAxis;
 
-  return std::make_shared<const ScrewJointBase>(ScrewJointBase(
+  return boost::make_shared<const ScrewJointBase>(ScrewJointBase(
       "j1", wTj, l1, l2, joint_params, jScrewAxis.head<3>(), jScrewAxis));
 }
 


### PR DESCRIPTION
Make use of boost shared pointer standard across project.
This allows for Boost in wrapping.