### PR TITLE
Joint velocities optional for forward kinematics

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -259,10 +259,11 @@ class Robot {
   void print() const;
 
   FKResults forwardKinematics(
-      const gtdynamics::JointValues &joint_angles, const gtdynamics::JointValues &joint_vels,
-      const boost::optional<string> prior_link_name ,
-      const boost::optional<gtsam::Pose3> &prior_link_pose ,
-      const boost::optional<gtsam::Vector6> &prior_link_twist) const;
+      const gtdynamics::JointValues &joint_angles,
+      const boost::optional<gtdynamics::JointValues> &joint_velocities,
+      const boost::optional<string> &prior_link_name ,
+      const gtsam::Pose3 &prior_link_pose ,
+      const Vector &prior_link_twist) const;
 };
 
 #include <gtdynamics/universal_robot/sdf.h>

--- a/gtdynamics/universal_robot/Robot.h
+++ b/gtdynamics/universal_robot/Robot.h
@@ -64,7 +64,7 @@ class Robot {
    * @param[in] joints JointMap containing all joints
    * joints.
    */
-  explicit Robot(const LinkMap& links, const JointMap& joints);
+  explicit Robot(const LinkMap &links, const JointMap &joints);
 
   /// Return this robot's links.
   std::vector<LinkSharedPtr> links() const;
@@ -101,15 +101,16 @@ class Robot {
    * (will throw an error when invalid joint angle specification detected).
    *
    * @param[in] joint_angles joint angles for all joints
-   * @param[in] joint_vels joint velocities for all joints
+   * @param[in] joint_velocities joint velocities for all joints
    * @param[in] prior_link_name name of link with known pose & twist
    * @param[in] prior_link_pose pose of the known link
    * @param[in] prior_link_twist twist of the konwn link
    * @return poses and twists of all links
    */
   FKResults forwardKinematics(
-      const JointValues &joint_angles, const JointValues &joint_vels,
-      const boost::optional<std::string> prior_link_name = boost::none,
+      const JointValues &joint_angles,
+      const boost::optional<JointValues> &joint_velocities = boost::none,
+      const boost::optional<std::string> &prior_link_name = boost::none,
       const gtsam::Pose3 &prior_link_pose = gtsam::Pose3(),
       const gtsam::Vector6 &prior_link_twist = gtsam::Z_6x1) const;
 };


### PR DESCRIPTION
Updated `Robot::forwardKinematics` to make the joint velocities an optional parameter.

Also fixed the wrapping.