### PR TITLE
Separate `ScrewJointBase` implementations into cpp file

### DIFF
--- a/gtdynamics/universal_robot/ScrewJointBase.cpp
+++ b/gtdynamics/universal_robot/ScrewJointBase.cpp
@@ -1,0 +1,257 @@
+/* ----------------------------------------------------------------------------
+ * GTDynamics Copyright 2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file  ScrewJointBase.cpp
+ * @brief Representation of screw-type robot joints. Revolute, Prismatic, and
+ *  Screw subclasses
+ * @author Frank Dellaert
+ * @author Mandy Xie
+ * @author Alejandro Escontrela
+ * @author Yetong Zhang
+ * @author Stephanie McCormick
+ * @author Gerry Chen
+ * @author Varun Agrawal
+ */
+
+
+#include "gtdynamics/universal_robot/ScrewJointBase.h"
+
+#include "gtdynamics/factors/JointLimitFactor.h"
+#include "gtdynamics/universal_robot/Link.h"
+#include "gtdynamics/utils/utils.h"
+#include "gtdynamics/utils/values.h"
+
+#include <gtsam/geometry/Pose3.h>
+
+#include <cmath>
+#include <map>
+#include <string>
+
+using namespace gtsam;
+
+namespace gtdynamics {
+
+/* ************************************************************************* */
+Pose3 ScrewJointBase::parentTchild(
+    double q,
+    gtsam::OptionalJacobian<6, 1> pMc_H_q) const {
+  if (pMc_H_q) {
+    gtsam::Matrix6 exp_H_Sq;
+    Vector6 Sq = cScrewAxis_ * q;
+    Pose3 exp = Pose3::Expmap(Sq, exp_H_Sq);
+    Pose3 pMc = pMccom_.compose(exp);  // derivative in exp is identity!
+    *pMc_H_q = exp_H_Sq * cScrewAxis_;
+    return pMc;
+  } else {
+    return pMccom_ * Pose3::Expmap(cScrewAxis_ * q);
+  }
+}
+
+/* ************************************************************************* */
+Pose3 ScrewJointBase::childTparent(
+    double q,
+    gtsam::OptionalJacobian<6, 1> cMp_H_q) const {
+  // TODO(frank): don't go via inverse, specialize in base class
+  if (cMp_H_q) {
+    gtsam::Matrix6 cMp_H_pMc;
+    Vector6 pMc_H_q;
+    Pose3 pMc = parentTchild(q, pMc_H_q);  // pMc(q)    ->  pMc_H_q
+    Pose3 cMp = pMc.inverse(cMp_H_pMc);    // cMp(pMc)  ->  cMp_H_pMc
+    *cMp_H_q = cMp_H_pMc * pMc_H_q;
+    return cMp;
+  } else {
+    return parentTchild(q).inverse();
+  }
+}
+
+/* ************************************************************************* */
+Vector6 ScrewJointBase::transformTwistTo(
+    const LinkSharedPtr &link, double q, double q_dot,
+    boost::optional<Vector6> other_twist,
+    gtsam::OptionalJacobian<6, 1> H_q,
+    gtsam::OptionalJacobian<6, 1> H_q_dot,
+    gtsam::OptionalJacobian<6, 6> H_other_twist) const {
+  Vector6 other_twist_ = other_twist ? *other_twist : Vector6::Zero();
+
+  auto other = otherLink(link);
+  auto this_ad_other = relativePoseOf(other, q).AdjointMap();
+
+  if (H_q) {
+    // TODO(frank): really, zero below? Check derivatives
+    *H_q = AdjointMapJacobianQ(q, relativePoseOf(other, 0.0), screwAxis(link)) *
+           other_twist_;
+  }
+  if (H_q_dot) {
+    *H_q_dot = screwAxis(link);
+  }
+  if (H_other_twist) {
+    *H_other_twist = this_ad_other;
+  }
+
+  return this_ad_other * other_twist_ + screwAxis(link) * q_dot;
+}
+
+/* ************************************************************************* */
+Vector6 ScrewJointBase::transformTwistAccelTo(
+    const LinkSharedPtr &link, double q, double q_dot, double q_ddot,
+    boost::optional<Vector6> this_twist,
+    boost::optional<Vector6> other_twist_accel,
+    gtsam::OptionalJacobian<6, 1> H_q,
+    gtsam::OptionalJacobian<6, 1> H_q_dot,
+    gtsam::OptionalJacobian<6, 1> H_q_ddot,
+    gtsam::OptionalJacobian<6, 6> H_this_twist,
+    gtsam::OptionalJacobian<6, 6> H_other_twist_accel) const {
+  Vector6 this_twist_ = this_twist ? *this_twist : Vector6::Zero();
+  Vector6 other_twist_accel_ =
+      other_twist_accel ? *other_twist_accel : Vector6::Zero();
+  Vector6 screw_axis_ = isChildLink(link) ? cScrewAxis_ : pScrewAxis_;
+
+  // i = other link
+  // j = this link
+  auto other = otherLink(link);
+  Pose3 jTi = relativePoseOf(other, q);
+
+  Vector6 this_twist_accel =
+      jTi.AdjointMap() * other_twist_accel_ +
+      Pose3::adjoint(this_twist_, screw_axis_ * q_dot, H_this_twist) +
+      screw_axis_ * q_ddot;
+
+  if (H_other_twist_accel) {
+    *H_other_twist_accel = jTi.AdjointMap();
+  }
+  if (H_q) {
+    // TODO(frank): really, zero below? Check derivatives. Also, copy/pasta from
+    // above?
+    *H_q = AdjointMapJacobianQ(q, relativePoseOf(other, 0.0), screw_axis_) *
+           other_twist_accel_;
+  }
+  if (H_q_dot) {
+    *H_q_dot = Pose3::adjointMap(this_twist_) * screw_axis_;
+  }
+  if (H_q_ddot) {
+    *H_q_ddot = screw_axis_;
+  }
+
+  return this_twist_accel;
+}
+
+/* ************************************************************************* */
+ScrewJointBase::JointTorque ScrewJointBase::transformWrenchToTorque(
+    const LinkSharedPtr &link, boost::optional<Vector6> wrench,
+    gtsam::OptionalJacobian<1, 6> H_wrench) const {
+  auto screw_axis_ = screwAxis(link);
+  if (H_wrench) {
+    *H_wrench = screw_axis_.transpose();
+  }
+  return screw_axis_.transpose() * (wrench ? *wrench : Vector6::Zero());
+}
+
+/* ************************************************************************* */
+gtsam::GaussianFactorGraph ScrewJointBase::linearFDPriors(
+    size_t t, const gtsam::Values &known_values,
+    const OptimizerSetting &opt) const {
+  gtsam::GaussianFactorGraph priors;
+  gtsam::Vector1 rhs(Torque(known_values, id(), t));
+  // TODO(alej`andro): use optimizer settings
+  priors.add(internal::TorqueKey(id(), t), gtsam::I_1x1, rhs,
+             gtsam::noiseModel::Constrained::All(1));
+  return priors;
+}
+
+/* ************************************************************************* */
+gtsam::GaussianFactorGraph ScrewJointBase::linearAFactors(
+    size_t t, const gtsam::Values &known_values, const OptimizerSetting &opt,
+    const boost::optional<gtsam::Vector3> &planar_axis) const {
+  gtsam::GaussianFactorGraph graph;
+
+  const Pose3 T_wi1 = Pose(known_values, parent()->id(), t);
+  const Pose3 T_wi2 = Pose(known_values, child()->id(), t);
+  const Pose3 T_i2i1 = T_wi2.inverse() * T_wi1;
+  const Vector6 V_i2 = Twist(known_values, child()->id(), t);
+  const Vector6 S_i2_j = screwAxis(child_link_);
+  const double v_j = JointAngle(known_values, id(), t);
+
+  // twist acceleration factor
+  // A_i2 - Ad(T_21) * A_i1 - S_i2_j * a_j = ad(V_i2) * S_i2_j * v_j
+  Vector6 rhs_tw = Pose3::adjointMap(V_i2) * S_i2_j * v_j;
+  graph.add(internal::TwistAccelKey(child()->id(), t), gtsam::I_6x6,
+            internal::TwistAccelKey(parent()->id(), t), -T_i2i1.AdjointMap(),
+            internal::JointAccelKey(id(), t), -S_i2_j, rhs_tw,
+            gtsam::noiseModel::Constrained::All(6));
+
+  return graph;
+}
+
+/* ************************************************************************* */
+gtsam::GaussianFactorGraph ScrewJointBase::linearDynamicsFactors(
+    size_t t, const gtsam::Values &known_values, const OptimizerSetting &opt,
+    const boost::optional<gtsam::Vector3> &planar_axis) const {
+  gtsam::GaussianFactorGraph graph;
+
+  const Pose3 T_wi1 = Pose(known_values, parent()->id(), t);
+  const Pose3 T_wi2 = Pose(known_values, child()->id(), t);
+  const Pose3 T_i2i1 = T_wi2.inverse() * T_wi1;
+  const Vector6 S_i2_j = screwAxis(child_link_);
+
+  // torque factor
+  // S_i_j^T * F_i_j - tau = 0
+  gtsam::Vector1 rhs_torque = gtsam::Vector1::Zero();
+  graph.add(internal::WrenchKey(child()->id(), id(), t), S_i2_j.transpose(),
+            internal::TorqueKey(id(), t), -gtsam::I_1x1, rhs_torque,
+            gtsam::noiseModel::Constrained::All(1));
+
+  // wrench equivalence factor
+  // F_i1_j + Ad(T_i2i1)^T F_i2_j = 0
+  Vector6 rhs_weq = Vector6::Zero();
+  graph.add(internal::WrenchKey(parent()->id(), id(), t), gtsam::I_6x6,
+            internal::WrenchKey(child()->id(), id(), t),
+            T_i2i1.AdjointMap().transpose(), rhs_weq,
+            gtsam::noiseModel::Constrained::All(6));
+
+  // wrench planar factor
+  if (planar_axis) {
+    gtsam::Matrix36 J_wrench = getPlanarJacobian(*planar_axis);
+    graph.add(internal::WrenchKey(child()->id(), id(), t), J_wrench,
+              gtsam::Vector3::Zero(), gtsam::noiseModel::Constrained::All(3));
+  }
+
+  return graph;
+}
+
+/* ************************************************************************* */
+gtsam::NonlinearFactorGraph ScrewJointBase::jointLimitFactors(
+    size_t t, const OptimizerSetting &opt) const {
+  gtsam::NonlinearFactorGraph graph;
+  auto id = this->id();
+  // Add joint angle limit factor.
+  graph.emplace_shared<JointLimitFactor>(
+      internal::JointAngleKey(id, t), opt.jl_cost_model,
+      parameters().scalar_limits.value_lower_limit,
+      parameters().scalar_limits.value_upper_limit,
+      parameters().scalar_limits.value_limit_threshold);
+
+  // Add joint velocity limit factors.
+  graph.emplace_shared<JointLimitFactor>(
+      internal::JointVelKey(id, t), opt.jl_cost_model,
+      -parameters().velocity_limit, parameters().velocity_limit,
+      parameters().velocity_limit_threshold);
+
+  // Add joint acceleration limit factors.
+  graph.emplace_shared<JointLimitFactor>(
+      internal::JointAccelKey(id, t), opt.jl_cost_model,
+      -parameters().acceleration_limit, parameters().acceleration_limit,
+      parameters().acceleration_limit_threshold);
+
+  // Add joint torque limit factors.
+  graph.emplace_shared<JointLimitFactor>(
+      internal::TorqueKey(id, t), opt.jl_cost_model, -parameters().torque_limit,
+      parameters().torque_limit, parameters().torque_limit_threshold);
+  return graph;
+}
+
+}  // namespace gtdynamics

--- a/gtdynamics/universal_robot/ScrewJointBase.h
+++ b/gtdynamics/universal_robot/ScrewJointBase.h
@@ -53,35 +53,12 @@ class ScrewJointBase : public JointTyped {
  public:
   /// Return transform of child link com frame w.r.t parent link com frame
   Pose3 parentTchild(double q, gtsam::OptionalJacobian<6, 1> pMc_H_q =
-                                   boost::none) const override {
-    if (pMc_H_q) {
-      gtsam::Matrix6 exp_H_Sq;
-      Vector6 Sq = cScrewAxis_ * q;
-      Pose3 exp = Pose3::Expmap(Sq, exp_H_Sq);
-      Pose3 pMc = pMccom_.compose(exp); // derivative in exp is identity!
-      *pMc_H_q = exp_H_Sq * cScrewAxis_;
-      return pMc;
-    } else {
-      return pMccom_ * Pose3::Expmap(cScrewAxis_ * q);
-    }
-  }
+                                   boost::none) const override;
 
-protected:
+ protected:
   /// Return transform of parent link com frame w.r.t child link com frame
   Pose3 childTparent(double q, gtsam::OptionalJacobian<6, 1> cMp_H_q =
-                                   boost::none) const override {
-    // TODO(frank): don't go via inverse, specialize in base class
-    if (cMp_H_q) {
-      gtsam::Matrix6 cMp_H_pMc;
-      Vector6 pMc_H_q;
-      Pose3 pMc = parentTchild(q, pMc_H_q); // pMc(q)    ->  pMc_H_q
-      Pose3 cMp = pMc.inverse(cMp_H_pMc);   // cMp(pMc)  ->  cMp_H_pMc
-      *cMp_H_q = cMp_H_pMc * pMc_H_q;
-      return cMp;
-    } else {
-      return parentTchild(q).inverse();
-    }
-  }
+                                   boost::none) const override;
 
   /**
    * Return the joint axis in the joint frame. Rotational axis for revolute and
@@ -120,32 +97,12 @@ protected:
   /**
    * Return the twist of this link given the other link's twist and joint angle.
    */
-  Vector6 transformTwistTo(const LinkSharedPtr &link, double q, double q_dot,
-                           boost::optional<Vector6> other_twist = boost::none,
-                           gtsam::OptionalJacobian<6, 1> H_q = boost::none,
-                           gtsam::OptionalJacobian<6, 1> H_q_dot = boost::none,
-                           gtsam::OptionalJacobian<6, 6> H_other_twist =
-                               boost::none) const override {
-    Vector6 other_twist_ = other_twist ? *other_twist : Vector6::Zero();
-
-    auto other = otherLink(link);
-    auto this_ad_other = relativePoseOf(other, q).AdjointMap();
-
-    if (H_q) {
-      // TODO(frank): really, zero below? Check derivatives
-      *H_q =
-          AdjointMapJacobianQ(q, relativePoseOf(other, 0.0), screwAxis(link)) *
-          other_twist_;
-    }
-    if (H_q_dot) {
-      *H_q_dot = screwAxis(link);
-    }
-    if (H_other_twist) {
-      *H_other_twist = this_ad_other;
-    }
-
-    return this_ad_other * other_twist_ + screwAxis(link) * q_dot;
-  }
+  Vector6 transformTwistTo(
+      const LinkSharedPtr &link, double q, double q_dot,
+      boost::optional<Vector6> other_twist = boost::none,
+      gtsam::OptionalJacobian<6, 1> H_q = boost::none,
+      gtsam::OptionalJacobian<6, 1> H_q_dot = boost::none,
+      gtsam::OptionalJacobian<6, 6> H_other_twist = boost::none) const override;
 
   /**
    * Return the twist acceleration of this link given the other link's twist
@@ -160,49 +117,11 @@ protected:
       gtsam::OptionalJacobian<6, 1> H_q_ddot = boost::none,
       gtsam::OptionalJacobian<6, 6> H_this_twist = boost::none,
       gtsam::OptionalJacobian<6, 6> H_other_twist_accel =
-          boost::none) const override {
-    Vector6 this_twist_ = this_twist ? *this_twist : Vector6::Zero();
-    Vector6 other_twist_accel_ =
-        other_twist_accel ? *other_twist_accel : Vector6::Zero();
-    Vector6 screw_axis_ = isChildLink(link) ? cScrewAxis_ : pScrewAxis_;
-
-    // i = other link
-    // j = this link
-    auto other = otherLink(link);
-    Pose3 jTi = relativePoseOf(other, q);
-
-    Vector6 this_twist_accel =
-        jTi.AdjointMap() * other_twist_accel_ +
-        Pose3::adjoint(this_twist_, screw_axis_ * q_dot, H_this_twist) +
-        screw_axis_ * q_ddot;
-
-    if (H_other_twist_accel) {
-      *H_other_twist_accel = jTi.AdjointMap();
-    }
-    if (H_q) {
-      // TODO(frank): really, zero below? Check derivatives. Also, copy/pasta from above?
-      *H_q = AdjointMapJacobianQ(q, relativePoseOf(other, 0.0), screw_axis_) *
-             other_twist_accel_;
-    }
-    if (H_q_dot) {
-      *H_q_dot = Pose3::adjointMap(this_twist_) * screw_axis_;
-    }
-    if (H_q_ddot) {
-      *H_q_ddot = screw_axis_;
-    }
-
-    return this_twist_accel;
-  }
+          boost::none) const override;
 
   JointTorque transformWrenchToTorque(
       const LinkSharedPtr &link, boost::optional<Vector6> wrench = boost::none,
-      gtsam::OptionalJacobian<1, 6> H_wrench = boost::none) const override {
-    auto screw_axis_ = screwAxis(link);
-    if (H_wrench) {
-      *H_wrench = screw_axis_.transpose();
-    }
-    return screw_axis_.transpose() * (wrench ? *wrench : Vector6::Zero());
-  }
+      gtsam::OptionalJacobian<1, 6> H_wrench = boost::none) const override;
 
   // TODO(frank): document and possibly eliminate
   gtsam::Matrix6 AdjointMapJacobianJointAngle(const LinkSharedPtr &link,
@@ -214,105 +133,22 @@ protected:
   /// Return forward dynamics priors on torque.
   gtsam::GaussianFactorGraph linearFDPriors(
       size_t t, const gtsam::Values &known_values,
-      const OptimizerSetting &opt) const override {
-    gtsam::GaussianFactorGraph priors;
-    gtsam::Vector1 rhs(Torque(known_values, id(), t));
-    // TODO(alej`andro): use optimizer settings
-    priors.add(internal::TorqueKey(id(), t), gtsam::I_1x1, rhs,
-               gtsam::noiseModel::Constrained::All(1));
-    return priors;
-  }
+      const OptimizerSetting &opt) const override;
 
   /// Return linearized acceleration factors.
   gtsam::GaussianFactorGraph linearAFactors(
       size_t t, const gtsam::Values &known_values, const OptimizerSetting &opt,
-      const boost::optional<gtsam::Vector3> &planar_axis) const override {
-    gtsam::GaussianFactorGraph graph;
-
-    const Pose3 T_wi1 = Pose(known_values, parent()->id(), t);
-    const Pose3 T_wi2 = Pose(known_values, child()->id(), t);
-    const Pose3 T_i2i1 = T_wi2.inverse() * T_wi1;
-    const Vector6 V_i2 = Twist(known_values, child()->id(), t);
-    const Vector6 S_i2_j = screwAxis(child_link_);
-    const double v_j = JointAngle(known_values, id(), t);
-
-    // twist acceleration factor
-    // A_i2 - Ad(T_21) * A_i1 - S_i2_j * a_j = ad(V_i2) * S_i2_j * v_j
-    Vector6 rhs_tw = Pose3::adjointMap(V_i2) * S_i2_j * v_j;
-    graph.add(internal::TwistAccelKey(child()->id(), t), gtsam::I_6x6,
-              internal::TwistAccelKey(parent()->id(), t), -T_i2i1.AdjointMap(),
-              internal::JointAccelKey(id(), t), -S_i2_j, rhs_tw,
-              gtsam::noiseModel::Constrained::All(6));
-
-    return graph;
-  }
+      const boost::optional<gtsam::Vector3> &planar_axis) const override;
 
   /// Return linearized dynamics factors.
   gtsam::GaussianFactorGraph linearDynamicsFactors(
       size_t t, const gtsam::Values &known_values, const OptimizerSetting &opt,
-      const boost::optional<gtsam::Vector3> &planar_axis) const override {
-    gtsam::GaussianFactorGraph graph;
-
-    const Pose3 T_wi1 = Pose(known_values, parent()->id(), t);
-    const Pose3 T_wi2 = Pose(known_values, child()->id(), t);
-    const Pose3 T_i2i1 = T_wi2.inverse() * T_wi1;
-    const Vector6 S_i2_j = screwAxis(child_link_);
-
-    // torque factor
-    // S_i_j^T * F_i_j - tau = 0
-    gtsam::Vector1 rhs_torque = gtsam::Vector1::Zero();
-    graph.add(internal::WrenchKey(child()->id(), id(), t), S_i2_j.transpose(),
-              internal::TorqueKey(id(), t), -gtsam::I_1x1, rhs_torque,
-              gtsam::noiseModel::Constrained::All(1));
-
-    // wrench equivalence factor
-    // F_i1_j + Ad(T_i2i1)^T F_i2_j = 0
-    Vector6 rhs_weq = Vector6::Zero();
-    graph.add(internal::WrenchKey(parent()->id(), id(), t), gtsam::I_6x6,
-              internal::WrenchKey(child()->id(), id(), t),
-              T_i2i1.AdjointMap().transpose(), rhs_weq,
-              gtsam::noiseModel::Constrained::All(6));
-
-    // wrench planar factor
-    if (planar_axis) {
-      gtsam::Matrix36 J_wrench = getPlanarJacobian(*planar_axis);
-      graph.add(internal::WrenchKey(child()->id(), id(), t), J_wrench,
-                gtsam::Vector3::Zero(), gtsam::noiseModel::Constrained::All(3));
-    }
-
-    return graph;
-  }
+      const boost::optional<gtsam::Vector3> &planar_axis) const override;
 
 
   /// Return joint limit factors.
   gtsam::NonlinearFactorGraph jointLimitFactors(
-      size_t t, const OptimizerSetting &opt) const override {
-    gtsam::NonlinearFactorGraph graph;
-    auto id = this->id();
-    // Add joint angle limit factor.
-    graph.emplace_shared<JointLimitFactor>(
-        internal::JointAngleKey(id, t), opt.jl_cost_model,
-        parameters().scalar_limits.value_lower_limit,
-        parameters().scalar_limits.value_upper_limit,
-        parameters().scalar_limits.value_limit_threshold);
-
-    // Add joint velocity limit factors.
-    graph.emplace_shared<JointLimitFactor>(
-        internal::JointVelKey(id, t), opt.jl_cost_model, -parameters().velocity_limit,
-        parameters().velocity_limit, parameters().velocity_limit_threshold);
-
-    // Add joint acceleration limit factors.
-    graph.emplace_shared<JointLimitFactor>(
-        internal::JointAccelKey(id, t), opt.jl_cost_model,
-        -parameters().acceleration_limit, parameters().acceleration_limit,
-        parameters().acceleration_limit_threshold);
-
-    // Add joint torque limit factors.
-    graph.emplace_shared<JointLimitFactor>(
-        internal::TorqueKey(id, t), opt.jl_cost_model, -parameters().torque_limit,
-        parameters().torque_limit, parameters().torque_limit_threshold);
-    return graph;
-  }
+      size_t t, const OptimizerSetting &opt) const override;
 
   /// Joint-induced twist in child frame
   gtsam::Vector6 childTwist(double q_dot) const override {


### PR DESCRIPTION
Currently, `ScrewJointBase`'s implementation is in the .h file.  I'm not sure why we made it this way, but it makes readability difficult and increases compile times.

I hope you'll trust me that this PR doesn't do anything other than move code to a different file, because I assume the diff is going to be difficult to read.