### PR TITLE
Fix Running Examples installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mkdir build; cd build
 If GTDynamics was installed to `~/JohnDoe/gtdynamics_install`, then run the cmake command with:
 
 ```bash
-cmake ../ -DCMAKE_PREFIX_PATH=~/JohnDoe/gtdynamics_install
+cmake -DCMAKE_PREFIX_PATH=~/JohnDoe/gtdynamics_install ..
 make
 ```
 


### PR DESCRIPTION
Fix step 2 of running examples in README.md from
`cmake -DCMAKE_PREFIX_PATH=~/JohnDoe/gtdynamics_install
`

to

`cmake ../ -DCMAKE_PREFIX_PATH=~/JohnDoe/gtdynamics_install
`