### PR TITLE
Remove Vector-based return

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -417,27 +417,8 @@ class DynamicsGraph {
                                    const gtsam::Values &result, const int t);
 
   /* return joint torques. */
-  static Vector jointTorques(const gtdynamics::Robot &robot,
+  static gtsam::Values jointTorques(const gtdynamics::Robot &robot,
                                     const gtsam::Values &result, const int t);
-
-  static gtdynamics::JointValueMap jointAccelsMap(const gtdynamics::Robot &robot,
-                                           const gtsam::Values &result,
-                                           const int t);
-
-  /* return joint velocities as std::map<name, velocity>. */
-  static gtdynamics::JointValueMap jointVelsMap(const gtdynamics::Robot &robot,
-                                         const gtsam::Values &result,
-                                         const int t);
-
-  /* return joint angles as std::map<name, angle>. */
-  static gtdynamics::JointValueMap jointAnglesMap(const gtdynamics::Robot &robot,
-                                           const gtsam::Values &result,
-                                           const int t);
-
-  /* return joint torques as std::map<name, torque>. */
-  static gtdynamics::JointValueMap jointTorquesMap(const gtdynamics::Robot &robot,
-                                            const gtsam::Values &result,
-                                            const int t);
 
   /* print the factors of the factor graph */
   static void printGraph(const gtsam::NonlinearFactorGraph &graph);

--- a/gtdynamics/dynamics/DynamicsGraph.cpp
+++ b/gtdynamics/dynamics/DynamicsGraph.cpp
@@ -596,102 +596,46 @@ DynamicsGraph::targetPoseFactors(const Robot &robot, const int t,
   return graph;
 }
 
-gtsam::Vector DynamicsGraph::jointAccels(const Robot &robot,
+gtsam::Values DynamicsGraph::jointAccels(const Robot &robot,
                                          const gtsam::Values &result,
                                          const int t) {
-  gtsam::Vector joint_accels = gtsam::Vector::Zero(robot.numJoints());
-  auto joints = robot.joints();
-  for (int idx = 0; idx < robot.numJoints(); idx++) {
-    auto joint = joints[idx];
+  gtsam::Values joint_accels;
+  for(auto&& joint: robot.joints()) {
     int j = joint->id();
-    joint_accels[idx] = JointAccel(result, j, t);
+    InsertJointAccel(&joint_accels, j, t, JointAccel(result, j, t));
   }
   return joint_accels;
 }
 
-gtsam::Vector DynamicsGraph::jointVels(const Robot &robot,
+gtsam::Values DynamicsGraph::jointVels(const Robot &robot,
                                        const gtsam::Values &result,
                                        const int t) {
-  gtsam::Vector joint_vels = gtsam::Vector::Zero(robot.numJoints());
-  auto joints = robot.joints();
-  for (int idx = 0; idx < robot.numJoints(); idx++) {
-    auto joint = joints[idx];
+  gtsam::Values joint_vels;
+  for(auto&& joint: robot.joints()) {
     int j = joint->id();
-    joint_vels[idx] = JointVel(result, j, t);
+    InsertJointVel(&joint_vels, j, t, JointVel(result, j, t));
   }
   return joint_vels;
 }
 
-gtsam::Vector DynamicsGraph::jointAngles(const Robot &robot,
+gtsam::Values DynamicsGraph::jointAngles(const Robot &robot,
                                          const gtsam::Values &result,
                                          const int t) {
-  gtsam::Vector joint_angles = gtsam::Vector::Zero(robot.numJoints());
-  auto joints = robot.joints();
-  for (int idx = 0; idx < robot.numJoints(); idx++) {
-    auto joint = joints[idx];
+  gtsam::Values joint_angles;
+  for(auto&& joint: robot.joints()) {
     int j = joint->id();
-    joint_angles[idx] = JointAngle(result, j, t);
+    InsertJointAngle(&joint_angles, j, t, JointAngle(result, j, t));
   }
   return joint_angles;
 }
 
-gtsam::Vector DynamicsGraph::jointTorques(const Robot &robot,
+gtsam::Values DynamicsGraph::jointTorques(const Robot &robot,
                                           const gtsam::Values &result,
                                           const int t) {
-  gtsam::Vector joint_torques = gtsam::Vector::Zero(robot.numJoints());
-  auto joints = robot.joints();
-  for (int idx = 0; idx < robot.numJoints(); idx++) {
-    auto joint = joints[idx];
+  gtsam::Values joint_torques;
+  for(auto&& joint: robot.joints()) {
     int j = joint->id();
-    joint_torques[idx] = Torque(result, j, t);
-  }
-  return joint_torques;
-}
-
-JointValueMap DynamicsGraph::jointAccelsMap(const Robot &robot,
-                                          const gtsam::Values &result,
-                                          const int t) {
-  JointValueMap joint_accels;
-  for (auto &&joint : robot.joints()) {
-    int j = joint->id();
-    std::string name = joint->name();
-    joint_accels[name] = JointAccel(result, j, t);
-  }
-  return joint_accels;
-}
-
-JointValueMap DynamicsGraph::jointVelsMap(const Robot &robot,
-                                        const gtsam::Values &result,
-                                        const int t) {
-  JointValueMap joint_vels;
-  for (auto &&joint : robot.joints()) {
-    int j = joint->id();
-    std::string name = joint->name();
-    joint_vels[name] = JointVel(result, j, t);
-  }
-  return joint_vels;
-}
-
-JointValueMap DynamicsGraph::jointAnglesMap(const Robot &robot,
-                                          const gtsam::Values &result,
-                                          const int t) {
-  JointValueMap joint_angles;
-  for (auto &&joint : robot.joints()) {
-    int j = joint->id();
-    std::string name = joint->name();
-    joint_angles[name] = JointAngle(result, j, t);
-  }
-  return joint_angles;
-}
-
-JointValueMap DynamicsGraph::jointTorquesMap(const Robot &robot,
-                                           const gtsam::Values &result,
-                                           const int t) {
-  JointValueMap joint_torques;
-  for (auto &&joint : robot.joints()) {
-    int j = joint->id();
-    std::string name = joint->name();
-    joint_torques[name] = Torque(result, j, t);
+    InsertTorque(&joint_torques, j, t, Torque(result, j, t));
   }
   return joint_torques;
 }

--- a/gtdynamics/dynamics/DynamicsGraph.h
+++ b/gtdynamics/dynamics/DynamicsGraph.h
@@ -311,40 +311,20 @@ class DynamicsGraph {
    * @param robot the robot
    * @param t     time step
    */
-  static gtsam::Vector jointAccels(const Robot &robot,
+  static gtsam::Values jointAccels(const Robot &robot,
                                    const gtsam::Values &result, const int t);
 
   /// Return joint velocities.
-  static gtsam::Vector jointVels(const Robot &robot,
+  static gtsam::Values jointVels(const Robot &robot,
                                  const gtsam::Values &result, const int t);
 
   /// Return joint angles.
-  static gtsam::Vector jointAngles(const Robot &robot,
+  static gtsam::Values jointAngles(const Robot &robot,
                                    const gtsam::Values &result, const int t);
 
   /// Return joint torques.
-  static gtsam::Vector jointTorques(const Robot &robot,
+  static gtsam::Values jointTorques(const Robot &robot,
                                     const gtsam::Values &result, const int t);
-
-  /**
-   * Return the joint accelerations as std::map<name, acceleration>
-   * @param robot the robot
-   * @param t     time step
-   */
-  static JointValueMap jointAccelsMap(const Robot &robot,
-                                    const gtsam::Values &result, const int t);
-
-  /// Return joint velocities as std::map<name, velocity>.
-  static JointValueMap jointVelsMap(const Robot &robot,
-                                  const gtsam::Values &result, const int t);
-
-  /// Return joint angles as std::map<name, angle>.
-  static JointValueMap jointAnglesMap(const Robot &robot,
-                                    const gtsam::Values &result, const int t);
-
-  /// Return joint torques as std::map<name, torque>.
-  static JointValueMap jointTorquesMap(const Robot &robot,
-                                     const gtsam::Values &result, const int t);
 
   /// Rrint the factors of the factor graph
   static void printGraph(const gtsam::NonlinearFactorGraph &graph);


### PR DESCRIPTION
Making multiple small PRs to make reviewing easier.

Updated all the joint methods to return Values instead of Vector.