### PR TITLE
CI workflows for Actions

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -1,0 +1,63 @@
+name: Linux CI
+
+# TODO Uncomment when ready to enable CI
+# on: [pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.name }} ${{ matrix.build_type }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CTEST_OUTPUT_ON_FAILURE: ON
+      CTEST_PARALLEL_LEVEL: 2
+      CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
+      GTSAM_BUILD_UNSTABLE: ${{ matrix.build_unstable }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Github Actions requires a single row to be added to the build matrix.
+        # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
+        name: [
+          ubuntu-18.04-gcc-9,
+          ubuntu-18.04-clang-9,
+        ]
+
+        build_type: [Debug, Release]
+        build_unstable: [ON]
+        include:
+          - name: ubuntu-18.04-gcc-9
+            os: ubuntu-18.04
+            compiler: gcc
+            version: "9"
+
+          - name: ubuntu-18.04-clang-9
+            os: ubuntu-18.04
+            compiler: clang
+            version: "9"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Dependencies
+        run: |
+          brew tap osrf/simulation
+          brew install sdformat8
+          if [ "${{ matrix.compiler }}" = "gcc" ]; then
+            brew install gcc@${{ matrix.version }}
+            echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+            echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
+          else
+            sudo xcode-select -switch /Applications/Xcode_${{ matrix.version }}.app
+            echo "CC=clang" >> $GITHUB_ENV
+            echo "CXX=clang++" >> $GITHUB_ENV
+          fi
+      - name: Configure
+        run: cmake -DGTDYNAMICS_BUILD_PYTHON=OFF .. 
+        working-directory: ./build
+      - name: Build
+        run: make -j4
+        working-directory: ./build
+      - name: Test
+        run: make -j4 check
+        working-directory: ./build

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -1,0 +1,57 @@
+name: macOS CI
+
+# TODO Uncomment when ready to enable CI
+# on: [pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.name }} ${{ matrix.build_type }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CTEST_OUTPUT_ON_FAILURE: ON
+      CTEST_PARALLEL_LEVEL: 2
+      CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
+      GTSAM_BUILD_UNSTABLE: ${{ matrix.build_unstable }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Github Actions requires a single row to be added to the build matrix.
+        # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
+        name: [
+          macOS-10.15-xcode-11.3.1,
+        ]
+
+        build_type: [Debug, Release]
+        build_unstable: [ON]
+        include:
+          - name: macOS-10.15-xcode-11.3.1
+            os: macOS-10.15
+            compiler: xcode
+            version: "11.3.1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Dependencies
+        run: |
+          brew tap osrf/simulation
+          brew install sdformat8
+          if [ "${{ matrix.compiler }}" = "gcc" ]; then
+            brew install gcc@${{ matrix.version }}
+            echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+            echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
+          else
+            sudo xcode-select -switch /Applications/Xcode_${{ matrix.version }}.app
+            echo "CC=clang" >> $GITHUB_ENV
+            echo "CXX=clang++" >> $GITHUB_ENV
+          fi
+      - name: Configure
+        run: cmake -DGTDYNAMICS_BUILD_PYTHON=OFF .. 
+        working-directory: ./build
+      - name: Build
+        run: make -j4
+        working-directory: ./build
+      - name: Test
+        run: make -j4 check
+        working-directory: ./build


### PR DESCRIPTION
Added workflows for Linux and macOS.

The triggers are commented out since CI is not free for private repos. We can simply uncomment them once we release.