### PR TITLE
Check if fixed link exists when brute force searching

### DIFF
--- a/gtdynamics/universal_robot/Robot.cpp
+++ b/gtdynamics/universal_robot/Robot.cpp
@@ -156,9 +156,13 @@ LinkSharedPtr Robot::findRootLink(
     }
   } else {
     auto links = this->links();
-    root_link = *std::find_if(
-        links.rbegin(), links.rend(),
-        [](const LinkSharedPtr &link) { return link->isFixed(); });
+    auto links_iter =
+        std::find_if(links.rbegin(), links.rend(),
+                     [](const LinkSharedPtr &link) { return link->isFixed(); });
+    // If valid link is found by find_if, assign root_link to the iterator.
+    if (links_iter != links.rend()) {
+      root_link = *links_iter;
+    }
   }
   if (!root_link) {
     throw std::runtime_error(


### PR DESCRIPTION
We need to check if the returned iterator from `find_if` is not `links.end()` aka a valid link.

If not, then don't assign the root_link and thus throw an exception later.