### PR TITLE
Automatically python-install when python-tests is run

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -65,15 +65,19 @@ set_target_properties(
              RELWITHDEBINFO_POSTFIX "" # Otherwise you will have a wrong name
 )
 
+add_custom_command(
+  OUTPUT ${PROJECT_BINARY_DIR}/python/installed.txt
+  DEPENDS ${PROJECT_NAME}_py
+  COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/python/setup.py install
+  COMMAND touch ${PROJECT_BINARY_DIR}/python/installed.txt
+  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python)
 add_custom_target(
   python-install
-  COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/python/setup.py install
-  DEPENDS ${PROJECT_NAME}_py
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python)
+  DEPENDS ${PROJECT_BINARY_DIR}/python/installed.txt)
 
 # Custom make command to run all Python tests
 add_custom_target(
   python-test
   COMMAND ${PYTHON_EXECUTABLE} -m unittest discover
-  DEPENDS ${PROJECT_NAME}_py
+  DEPENDS python-install
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/python/tests)


### PR DESCRIPTION
This was possibly a reason for #126 

I went on a wild goose chase for ~1 hour when I couldn't figure out why `make python-tests` was always failing when I realized I forgot to `make python-install`.  In retrospect it seems obvious, but I expected `make python-tests` to automatically `make python-install` if it hadn't already been installed.  It really threw me off because `make python-tests` depends on `${PROJECT_NAME}_py` so it would re-build the wrapper, but then just not use it because it was never installed.

I just changed the install into a cmake command so that it can be used as a dependency for `make python-tests` and is only re-installed if it needs to be.