### PR TITLE
Move some wrapper-related code into function in wrap repo

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -20,28 +20,9 @@ configure_file(${GTDYNAMICS_PYTHON_PATH}/requirements.txt
 configure_file(${GTDYNAMICS_PYTHON_PATH}/templates/${PROJECT_NAME}.tpl
                ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.tpl)
 
-# concatenate the different wrapper interface files
-# check if any interface files changed
-foreach(INTERFACE_FILE ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}.i ${ADDITIONAL_INTERFACE_FILES})
-  if(NOT EXISTS ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.i OR
-     ${INTERFACE_FILE} IS_NEWER_THAN ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.i)
-    set(UPDATE_INTERFACE TRUE)
-  endif()
-  # trigger cmake on file change
-  set_property(DIRECTORY
-               APPEND
-               PROPERTY CMAKE_CONFIGURE_DEPENDS ${INTERFACE_FILE})
-endforeach()
-# if so, then update the overall interface file
-if (UPDATE_INTERFACE)
-  configure_file(${PROJECT_SOURCE_DIR}/${PROJECT_NAME}.i
-                 ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.i COPYONLY)
-  # append additional interface files to end of gtdynamics.i
-  foreach(INTERFACE_FILE ${ADDITIONAL_INTERFACE_FILES})
-    file(READ ${INTERFACE_FILE} interface_contents)
-    file(APPEND ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.i "${interface_contents}")
-  endforeach()
-endif()
+combine_interface_headers(
+  ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.i
+  ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}.i ${ADDITIONAL_INTERFACE_FILES})
 
 pybind_wrap(
   ${PROJECT_NAME}_py # target


### PR DESCRIPTION
Accidentally introduced a bug in #127 where, if the last time cmake ran it didn't update the interface file, then on subsequent `make` commands it won't "watch" to check if any .i files changed anymore.
This commit fixes that.