### PR TITLE
Python print Values and NonlinearFactorGraph

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -1,6 +1,8 @@
 // GTDynamics Wrapper Interface File
 
 virtual class gtsam::NonlinearFactor;
+virtual class gtsam::NonlinearFactorGraph;
+virtual class gtsam::Values;
 
 namespace gtdynamics {
 
@@ -507,6 +509,11 @@ gtdynamics::DynamicsSymbol ContactWrenchKey(int i, int k, int t);
 gtdynamics::DynamicsSymbol PhaseKey(int k);
 gtdynamics::DynamicsSymbol TimeKey(int t);
 
+#include <gtdynamics/utils/DynamicsSymbol-wrap.h>
+string str(const gtsam::Values &t);
+string str(const gtsam::Values &t, const string &s);
+string str(const gtsam::NonlinearFactorGraph &t);
+string str(const gtsam::NonlinearFactorGraph &t, const string &s);
 
 ///////////////////// Key Methods /////////////////////
 template<T = {double}>

--- a/gtdynamics/utils/DynamicsSymbol-wrap.h
+++ b/gtdynamics/utils/DynamicsSymbol-wrap.h
@@ -1,0 +1,28 @@
+/* ----------------------------------------------------------------------------
+ * GTDynamics Copyright 2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file  DynamicsSymbol-wrap.h
+ * @brief This file provides convenience stuff for wrapping.  It wraps some
+ * gtsam objects so that printing will use DynamicsSymbol key formatting.
+ * @author Gerry Chen
+ */
+
+#pragma once
+
+#include "gtsam/nonlinear/utilities.h"  // for RedirectCout.
+
+namespace gtdynamics {
+
+template <typename T>
+std::string str(const T& t, const std::string& s = "") {
+  gtsam::RedirectCout redirect;
+  t.print(s, GTDKeyFormatter);
+  return redirect.str();
+}
+
+}  // namespace gtdynamics

--- a/python/templates/__init__.py.in
+++ b/python/templates/__init__.py.in
@@ -1,2 +1,11 @@
 import gtsam
 from ${PROJECT_NAME}.${PROJECT_NAME} import *
+
+class GtdKeyFormatter(object):
+    def __repr__(self):
+        return str(self)
+
+class Values(GtdKeyFormatter, gtsam.Values):
+    pass
+class NonlinearFactorGraph(GtdKeyFormatter, gtsam.NonlinearFactorGraph):
+    pass

--- a/python/tests/test_print.py
+++ b/python/tests/test_print.py
@@ -1,0 +1,32 @@
+"""
+ * GTDynamics Copyright 2021, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * See LICENSE for the license information
+ *
+ * @file  test_print.py
+ * @brief Test printing with DynamicsSymbol.
+ * @author Gerry Chen
+"""
+
+import unittest
+
+import gtdynamics as gtd
+import gtsam
+
+class Print(unittest.TestCase):
+    def test_values(self):
+        """Checks that printing Values uses the GTDKeyFormatter instead of gtsam's default"""
+        v = gtd.Values()
+        gtd.InsertJointAngleDouble(v, 0, 1, 2)
+        self.assertTrue('q(0)1' in v.__repr__())
+
+    def test_nonlinear_factor_graph(self):
+        """Checks that printing NonlinearFactorGraph uses the GTDKeyFormatter"""
+        fg = gtd.NonlinearFactorGraph()
+        fg.push_back(gtd.MinTorqueFactor(gtd.internal.TorqueKey(0, 0).key(),
+                                         gtsam.noiseModel.Unit.Create(1)))
+        self.assertTrue('T(0)0' in fg.__repr__())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This fixes #131 by:
1) creating a static `gtdynamics::str(obj, s)` function that calls `obj.print(s, GTDKeyFormatter)`
2) creating pure-python "wrapper" classes around `gtsam.Values` and `gtsam.NonlinearFactorGraph` that override __repr__.  Based on [this SO answer](https://stackoverflow.com/a/931860/9151520).  Now use `gtd.Values` instead of `gtsam.Values` - it should behave identically in every way except it will print using GTDKeyFormatter instead.

```python
fg = gtd.NonlinearFactorGraph()
fg.push_back(gtd.MinTorqueFactor(gtd.internal.TorqueKey(0, 0).key(),
                                 gtsam.noiseModel.Unit.Create(1)))
print(fg)
```
will output:
```
size: 1

Factor 0: min torque factor
  keys = { T(0)0 }
  noise model: unit (1) 
```

I think I have also come up with a way make the GTDKeyFormatter function available in python (i.e. `kf = gtd.GetKeyFormatter; fg.print_('fg', kf)` and also supports functionals, but it will take some changes to wrap.  i'll put that (unit tests + one-liner) in a different PR after wrap PR.