### PR TITLE
Fix include path for cable factor tests

### DIFF
--- a/gtdynamics/cablerobot/tests/testCableLengthFactor.cpp
+++ b/gtdynamics/cablerobot/tests/testCableLengthFactor.cpp
@@ -5,7 +5,8 @@
  * @author Gerry Chen
  */
 
-#include "factors/CableLengthFactor.h"
+#include <gtdynamics/cablerobot/factors/CableLengthFactor.h>
+
 #include <gtdynamics/utils/values.h>
 
 #include <gtsam/base/Vector.h>

--- a/gtdynamics/cablerobot/tests/testCableTensionFactor.cpp
+++ b/gtdynamics/cablerobot/tests/testCableTensionFactor.cpp
@@ -5,7 +5,7 @@
  * @author Gerry Chen
  */
 
-#include "factors/CableTensionFactor.h"
+#include <gtdynamics/cablerobot/factors/CableTensionFactor.h>
 
 #include <gtdynamics/utils/values.h>
 

--- a/gtdynamics/cablerobot/tests/testCableVelocityFactor.cpp
+++ b/gtdynamics/cablerobot/tests/testCableVelocityFactor.cpp
@@ -5,7 +5,7 @@
  * @author Gerry Chen
  */
 
-#include "factors/CableVelocityFactor.h"
+#include <gtdynamics/cablerobot/factors/CableVelocityFactor.h>
 
 #include <gtdynamics/utils/values.h>
 


### PR DESCRIPTION
Earlier changes to cmake includes mean now cable robot factors have to be included from `<gtdynamics/cablerobot/factors/...>` instead of `"factors/..."`