### PR TITLE
Update python unit test for GTDKeyFormatter syntax

### DIFF
--- a/python/tests/test_print.py
+++ b/python/tests/test_print.py
@@ -35,7 +35,7 @@ class Print(unittest.TestCase):
         torqueKey = gtd.internal.TorqueKey(0, 0).key()
         factor = gtd.MinTorqueFactor(torqueKey, gtsam.noiseModel.Unit.Create(1))
         with patch('sys.stdout', new = StringIO()) as fake_out:
-            factor.print_('factor: ', gtd.GetKeyFormatter())
+            factor.print_('factor: ', gtd.GTDKeyFormatter)
             self.assertTrue('factor: min torque factor' in fake_out.getvalue())
             self.assertTrue('keys = { T(0)0 }' in fake_out.getvalue())
         def myKeyFormatter(key):


### PR DESCRIPTION
In #185 `KeyFormatter()` static function "hack" was changed to the "correct" way using global variables, but the unit test wasn't updated and I didn't catch it during review.  Fixed it here.