### PR TITLE
Require Sdformat 8.9.1 version exactly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,8 @@ endif()
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${GTSAM_DIR}/../GTSAMCMakeTools")
 
 # For parsing urdf/sdf files.
-find_package(sdformat8 REQUIRED)
+# Exact version required so that all tests pass.
+find_package(sdformat8 8.9.1 EXACT REQUIRED)
 
 # ##############################################################################
 # Dynamics library


### PR DESCRIPTION
Update CMake to use the specific version of sdformat8 since older versions have bugs which causes parser errors.