### PR TITLE
Access link and point in PointOnLink from wrapper

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -300,6 +300,10 @@ class ContactPoint {
 class PointOnLink {
   PointOnLink();
   PointOnLink(const gtdynamics::Link* link, const gtsam::Point3 &point);
+
+  gtdynamics::LinkSharedPtr link;
+  gtsam::Point3 point;
+
   gtsam::Point3 predict(const gtsam::Values &values, size_t k = 0) const;
   void print(const string &s = "");
 };


### PR DESCRIPTION
We can now do `point_on_link.link` and `point_on_link.point` to get the underlying values.