### PR TITLE
Refactor joint & link constructors

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -231,27 +231,30 @@ virtual class JointTyped : gtdynamics::Joint {
 virtual class ScrewJointBase : gtdynamics::JointTyped {};
 
 virtual class RevoluteJoint : gtdynamics::ScrewJointBase {
-  RevoluteJoint(int id, const string &name, const gtsam::Pose3 &wTj,
-                const gtdynamics::Link* parent_link,
-                const gtdynamics::Link* child_link,
-                const gtdynamics::JointParams &parameters, const Vector &axis);
+  RevoluteJoint(
+      int id, const string &name, const gtdynamics::Link *parent_link,
+      const gtdynamics::Link *child_link, const Vector &axis,
+      const gtdynamics::JointParams &parameters = gtdynamics::JointParams(),
+      const gtsam::Pose3 &wTj = gtsam::Pose3());
   void print(const string &s = "") const;
 };
 
 virtual class PrismaticJoint : gtdynamics::ScrewJointBase {
-  PrismaticJoint(int id, const string &name, const gtsam::Pose3 &wTj,
-                 const gtdynamics::Link* parent_link,
-                 const gtdynamics::Link* child_link,
-                 const gtdynamics::JointParams &parameters, const Vector &axis);
+  PrismaticJoint(
+      int id, const string &name, const gtdynamics::Link *parent_link,
+      const gtdynamics::Link *child_link, const Vector &axis,
+      const gtdynamics::JointParams &parameters = gtdynamics::JointParams(),
+      const gtsam::Pose3 &wTj = gtsam::Pose3());
   void print(const string &s = "") const;
 };
 
 virtual class ScrewJoint : gtdynamics::ScrewJointBase {
-  ScrewJoint(int id, const string &name, const gtsam::Pose3 &wTj,
-             const gtdynamics::Link* parent_link,
-             const gtdynamics::Link* child_link,
-             const gtdynamics::JointParams &parameters, const Vector &axis,
-             double thread_pitch);
+  ScrewJoint(
+      int id, const string &name, const gtdynamics::Link *parent_link,
+      const gtdynamics::Link *child_link, const Vector &axis,
+      double thread_pitch,
+      const gtdynamics::JointParams &parameters = gtdynamics::JointParams(),
+      const gtsam::Pose3 &wTj = gtsam::Pose3());
   void print(const string &s = "") const;
 };
 

--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -165,34 +165,33 @@ class ContactHeightFactor : gtsam::NonlinearFactor {
 /********************** link **********************/
 #include <gtdynamics/universal_robot/Link.h>
 class Link  {
-    Link();
-    Link(int id, const string &name_, const double mass_,
-         const Matrix &inertia_, const gtsam::Pose3 &wTl_,
-         const gtsam::Pose3 &lTcom_);
-    Link(int id, const string &name_, const double mass_,
-         const Matrix &inertia_, const gtsam::Pose3 &wTl_,
-         const gtsam::Pose3 &lTcom_, bool is_fixed);
+  Link();
+  Link(int id, const string &name, const double mass, const Matrix &inertia,
+       const gtsam::Pose3 &wTl, const gtsam::Pose3 &lTcom,
+       bool is_fixed = false);
+  Link(int id, const string &name, const double mass, const Matrix &inertia,
+       const gtsam::Pose3 &lTcom, bool is_fixed = false);
 
-    gtdynamics::Link* shared();
-    int id() const;
-    void addJoint(gtdynamics::Joint* joint_ptr);
-    const gtsam::Pose3 &wTl() const;
-    const gtsam::Pose3 &lTcom() const;
-    const gtsam::Pose3 wTcom() const;
-    const gtsam::Pose3 &getFixedPose() const;
-    bool isFixed() const;
-    void fix();
-    void fix(gtsam::Pose3 & fixed_pose);
-    void unfix();
-    const std::vector<Joint*> &joints() const;
-    size_t numJoints() const;
-    string name() const;
-    double mass() const;
-    const gtsam::Pose3 &centerOfMass();
-    const Matrix &inertia();
-    gtsam::Matrix6 inertiaMatrix();
+  gtdynamics::Link *shared();
+  int id() const;
+  void addJoint(gtdynamics::Joint *joint_ptr);
+  const gtsam::Pose3 &wTl() const;
+  const gtsam::Pose3 &lTcom() const;
+  const gtsam::Pose3 wTcom() const;
+  const gtsam::Pose3 &getFixedPose() const;
+  bool isFixed() const;
+  void fix();
+  void fix(gtsam::Pose3 &fixed_pose);
+  void unfix();
+  const std::vector<Joint *> &joints() const;
+  size_t numJoints() const;
+  string name() const;
+  double mass() const;
+  const gtsam::Pose3 &centerOfMass();
+  const Matrix &inertia();
+  gtsam::Matrix6 inertiaMatrix();
 
-    void print(const std::string &s = "") const;
+  void print(const std::string &s = "") const;
 };
 
 /********************** joint **********************/

--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -169,8 +169,6 @@ class Link  {
   Link(int id, const string &name, const double mass, const Matrix &inertia,
        const gtsam::Pose3 &wTl, const gtsam::Pose3 &lTcom,
        bool is_fixed = false);
-  Link(int id, const string &name, const double mass, const Matrix &inertia,
-       const gtsam::Pose3 &lTcom, bool is_fixed = false);
 
   gtdynamics::Link *shared();
   int id() const;
@@ -232,29 +230,28 @@ virtual class ScrewJointBase : gtdynamics::JointTyped {};
 
 virtual class RevoluteJoint : gtdynamics::ScrewJointBase {
   RevoluteJoint(
-      int id, const string &name, const gtdynamics::Link *parent_link,
-      const gtdynamics::Link *child_link, const Vector &axis,
-      const gtdynamics::JointParams &parameters = gtdynamics::JointParams(),
-      const gtsam::Pose3 &wTj = gtsam::Pose3());
+      int id, const string &name, const gtsam::Pose3 &wTj,
+      const gtdynamics::Link *parent_link, const gtdynamics::Link *child_link,
+      const Vector &axis,
+      const gtdynamics::JointParams &parameters = gtdynamics::JointParams());
   void print(const string &s = "") const;
 };
 
 virtual class PrismaticJoint : gtdynamics::ScrewJointBase {
   PrismaticJoint(
-      int id, const string &name, const gtdynamics::Link *parent_link,
-      const gtdynamics::Link *child_link, const Vector &axis,
-      const gtdynamics::JointParams &parameters = gtdynamics::JointParams(),
-      const gtsam::Pose3 &wTj = gtsam::Pose3());
+      int id, const string &name, const gtsam::Pose3 &wTj,
+      const gtdynamics::Link *parent_link, const gtdynamics::Link *child_link,
+      const Vector &axis,
+      const gtdynamics::JointParams &parameters = gtdynamics::JointParams());
   void print(const string &s = "") const;
 };
 
 virtual class ScrewJoint : gtdynamics::ScrewJointBase {
   ScrewJoint(
-      int id, const string &name, const gtdynamics::Link *parent_link,
-      const gtdynamics::Link *child_link, const Vector &axis,
-      double thread_pitch,
-      const gtdynamics::JointParams &parameters = gtdynamics::JointParams(),
-      const gtsam::Pose3 &wTj = gtsam::Pose3());
+      int id, const string &name, const gtsam::Pose3 &wTj,
+      const gtdynamics::Link *parent_link, const gtdynamics::Link *child_link,
+      const Vector &axis, double thread_pitch,
+      const gtdynamics::JointParams &parameters = gtdynamics::JointParams());
   void print(const string &s = "") const;
 };
 

--- a/gtdynamics/universal_robot/Joint.cpp
+++ b/gtdynamics/universal_robot/Joint.cpp
@@ -23,9 +23,9 @@
 namespace gtdynamics {
 
 /* ************************************************************************* */
-Joint::Joint(uint8_t id, const std::string &name,
+Joint::Joint(uint8_t id, const std::string &name, const Pose3 &wTj,
              const LinkSharedPtr &parent_link, const LinkSharedPtr &child_link,
-             const JointParams &parameters, const Pose3 &wTj)
+             const JointParams &parameters)
     : id_(id),
       name_(name),
       wTj_(wTj),

--- a/gtdynamics/universal_robot/Joint.cpp
+++ b/gtdynamics/universal_robot/Joint.cpp
@@ -23,9 +23,9 @@
 namespace gtdynamics {
 
 /* ************************************************************************* */
-Joint::Joint(uint8_t id, const std::string &name, const Pose3 &wTj,
+Joint::Joint(uint8_t id, const std::string &name,
              const LinkSharedPtr &parent_link, const LinkSharedPtr &child_link,
-             const JointParams &parameters)
+             const JointParams &parameters, const Pose3 &wTj)
     : id_(id),
       name_(name),
       wTj_(wTj),

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -132,11 +132,11 @@ class Joint : public boost::enable_shared_from_this<Joint> {
    * @param[in] wTj          joint pose expressed in world frame
    * @param[in] parent_link  Shared pointer to the parent Link.
    * @param[in] child_link   Shared pointer to the child Link.
+   * @param[in] parameters   The joint parameters.
    */
-  Joint(uint8_t id, const std::string &name, const LinkSharedPtr &parent_link,
-        const LinkSharedPtr &child_link,
-        const JointParams &parameters = JointParams(),
-        const Pose3 &wTj = gtsam::Pose3());
+  Joint(uint8_t id, const std::string &name, const Pose3 &wTj,
+        const LinkSharedPtr &parent_link, const LinkSharedPtr &child_link,
+        const JointParams &parameters = JointParams());
 
   /**
    * @brief Default destructor.

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -68,6 +68,8 @@ struct JointParams {
   double torque_limit_threshold = 0.0;
   double damping_coefficient = 0.0;
   double spring_coefficient = 0.0;
+
+  /// Constructor
   JointParams() {}
 };
 
@@ -131,9 +133,10 @@ class Joint : public boost::enable_shared_from_this<Joint> {
    * @param[in] parent_link  Shared pointer to the parent Link.
    * @param[in] child_link   Shared pointer to the child Link.
    */
-  Joint(uint8_t id, const std::string &name, const Pose3 &wTj,
-        const LinkSharedPtr &parent_link, const LinkSharedPtr &child_link,
-        const JointParams &parameters);
+  Joint(uint8_t id, const std::string &name, const LinkSharedPtr &parent_link,
+        const LinkSharedPtr &child_link,
+        const JointParams &parameters = JointParams(),
+        const Pose3 &wTj = gtsam::Pose3());
 
   /**
    * @brief Default destructor.

--- a/gtdynamics/universal_robot/Link.h
+++ b/gtdynamics/universal_robot/Link.h
@@ -92,28 +92,6 @@ class Link : public boost::enable_shared_from_this<Link> {
         lTcom_(lTcom),
         is_fixed_(is_fixed) {}
 
-  /**
-   * @brief Construct a new Link object with default pose in spatial frame.
-   * 
-   * @param id Link ID
-   * @param name The name of the link as defined in the SDF/URDF file.
-   * @param mass The mass of the link.
-   * @param inertia The inertial matrix of the link.
-   * @param wTl The pose of the link in the spatial frame.
-   * @param lTcom The transform of the link's CoM in the link frame.
-   * @param is_fixed Flag indicating if the link is fixed.
-   */
-  Link(uint8_t id, const std::string &name, const double mass,
-       const gtsam::Matrix3 &inertia, const gtsam::Pose3 &lTcom,
-       bool is_fixed = false)
-      : id_(id),
-        name_(name),
-        mass_(mass),
-        inertia_(inertia),
-        wTl_(gtsam::Pose3()),
-        lTcom_(lTcom),
-        is_fixed_(is_fixed) {}
-
   /** destructor */
   virtual ~Link() = default;
 

--- a/gtdynamics/universal_robot/Link.h
+++ b/gtdynamics/universal_robot/Link.h
@@ -71,9 +71,15 @@ class Link : public boost::enable_shared_from_this<Link> {
   Link() {}
 
   /**
-   * Initialize Link's inertial properties with a LinkParams instance.
-   *
-   * @param params LinkParams object containing link information.
+   * @brief Construct a new Link object.
+   * 
+   * @param id Link ID
+   * @param name The name of the link as defined in the SDF/URDF file.
+   * @param mass The mass of the link.
+   * @param inertia The inertial matrix of the link.
+   * @param wTl The pose of the link in the spatial frame.
+   * @param lTcom The transform of the link's CoM in the link frame.
+   * @param is_fixed Flag indicating if the link is fixed.
    */
   Link(uint8_t id, const std::string &name, const double mass,
        const gtsam::Matrix3 &inertia, const gtsam::Pose3 &wTl,
@@ -83,6 +89,28 @@ class Link : public boost::enable_shared_from_this<Link> {
         mass_(mass),
         inertia_(inertia),
         wTl_(wTl),
+        lTcom_(lTcom),
+        is_fixed_(is_fixed) {}
+
+  /**
+   * @brief Construct a new Link object with default pose in spatial frame.
+   * 
+   * @param id Link ID
+   * @param name The name of the link as defined in the SDF/URDF file.
+   * @param mass The mass of the link.
+   * @param inertia The inertial matrix of the link.
+   * @param wTl The pose of the link in the spatial frame.
+   * @param lTcom The transform of the link's CoM in the link frame.
+   * @param is_fixed Flag indicating if the link is fixed.
+   */
+  Link(uint8_t id, const std::string &name, const double mass,
+       const gtsam::Matrix3 &inertia, const gtsam::Pose3 &lTcom,
+       bool is_fixed = false)
+      : id_(id),
+        name_(name),
+        mass_(mass),
+        inertia_(inertia),
+        wTl_(gtsam::Pose3()),
         lTcom_(lTcom),
         is_fixed_(is_fixed) {}
 

--- a/gtdynamics/universal_robot/PrismaticJoint.h
+++ b/gtdynamics/universal_robot/PrismaticJoint.h
@@ -46,16 +46,15 @@ class PrismaticJoint : public ScrewJointBase {
    * @param[in] wTj           joint pose expressed in world frame
    * @param[in] parent_link   Shared pointer to the parent Link.
    * @param[in] child_link    Shared pointer to the child Link.
-   * @param[in] parameters    JointParams struct
    * @param[in] axis          joint axis expressed in joint frame
+   * @param[in] parameters    JointParams struct
    */
-  PrismaticJoint(uint8_t id, const std::string &name,
+  PrismaticJoint(uint8_t id, const std::string &name, const gtsam::Pose3 &wTj,
                  const LinkSharedPtr &parent_link,
                  const LinkSharedPtr &child_link, const gtsam::Vector3 &axis,
-                 const JointParams &parameters = JointParams(),
-                 const gtsam::Pose3 &wTj = gtsam::Pose3())
-      : ScrewJointBase(id, name, parent_link, child_link, axis,
-                       getScrewAxis(axis), parameters, wTj) {}
+                 const JointParams &parameters = JointParams())
+      : ScrewJointBase(id, name, wTj, parent_link, child_link, axis,
+                       getScrewAxis(axis), parameters) {}
 
   /// Return joint type for use in reconstructing robot from JointParams.
   Type type() const override { return Type::Prismatic; }

--- a/gtdynamics/universal_robot/PrismaticJoint.h
+++ b/gtdynamics/universal_robot/PrismaticJoint.h
@@ -49,12 +49,13 @@ class PrismaticJoint : public ScrewJointBase {
    * @param[in] parameters    JointParams struct
    * @param[in] axis          joint axis expressed in joint frame
    */
-  PrismaticJoint(uint8_t id, const std::string &name, const gtsam::Pose3 &wTj,
+  PrismaticJoint(uint8_t id, const std::string &name,
                  const LinkSharedPtr &parent_link,
-                 const LinkSharedPtr &child_link, const JointParams &parameters,
-                 const gtsam::Vector3 &axis)
-      : ScrewJointBase(id, name, wTj, parent_link, child_link, parameters, axis,
-                       getScrewAxis(axis)) {}
+                 const LinkSharedPtr &child_link, const gtsam::Vector3 &axis,
+                 const JointParams &parameters = JointParams(),
+                 const gtsam::Pose3 &wTj = gtsam::Pose3())
+      : ScrewJointBase(id, name, parent_link, child_link, axis,
+                       getScrewAxis(axis), parameters, wTj) {}
 
   /// Return joint type for use in reconstructing robot from JointParams.
   Type type() const override { return Type::Prismatic; }

--- a/gtdynamics/universal_robot/RevoluteJoint.h
+++ b/gtdynamics/universal_robot/RevoluteJoint.h
@@ -49,12 +49,13 @@ class RevoluteJoint : public ScrewJointBase {
    * @param[in] parameters    JointParams struct
    * @param[in] axis          joint axis expressed in joint frame
    */
-  RevoluteJoint(uint8_t id, const std::string &name, const gtsam::Pose3 &wTj,
+  RevoluteJoint(uint8_t id, const std::string &name,
                 const LinkSharedPtr &parent_link,
-                const LinkSharedPtr &child_link, const JointParams &parameters,
-                const gtsam::Vector3 &axis)
-      : ScrewJointBase(id, name, wTj, parent_link, child_link, parameters, axis,
-                       getScrewAxis(axis)) {}
+                const LinkSharedPtr &child_link, const gtsam::Vector3 &axis,
+                const JointParams &parameters = JointParams(),
+                const gtsam::Pose3 &wTj = gtsam::Pose3())
+      : ScrewJointBase(id, name, parent_link, child_link, axis,
+                       getScrewAxis(axis), parameters, wTj) {}
 
   /// Return joint type for use in reconstructing robot from JointParams.
   Type type() const override { return Type::Revolute; }

--- a/gtdynamics/universal_robot/RevoluteJoint.h
+++ b/gtdynamics/universal_robot/RevoluteJoint.h
@@ -46,16 +46,15 @@ class RevoluteJoint : public ScrewJointBase {
    * @param[in] wTj           joint pose expressed in world frame
    * @param[in] parent_link   Shared pointer to the parent Link.
    * @param[in] child_link    Shared pointer to the child Link.
-   * @param[in] parameters    JointParams struct
    * @param[in] axis          joint axis expressed in joint frame
+   * @param[in] parameters    JointParams struct
    */
-  RevoluteJoint(uint8_t id, const std::string &name,
+  RevoluteJoint(uint8_t id, const std::string &name, const gtsam::Pose3 &wTj,
                 const LinkSharedPtr &parent_link,
                 const LinkSharedPtr &child_link, const gtsam::Vector3 &axis,
-                const JointParams &parameters = JointParams(),
-                const gtsam::Pose3 &wTj = gtsam::Pose3())
-      : ScrewJointBase(id, name, parent_link, child_link, axis,
-                       getScrewAxis(axis), parameters, wTj) {}
+                const JointParams &parameters = JointParams())
+      : ScrewJointBase(id, name, wTj, parent_link, child_link, axis,
+                       getScrewAxis(axis), parameters) {}
 
   /// Return joint type for use in reconstructing robot from JointParams.
   Type type() const override { return Type::Revolute; }

--- a/gtdynamics/universal_robot/ScrewJoint.h
+++ b/gtdynamics/universal_robot/ScrewJoint.h
@@ -53,12 +53,13 @@ class ScrewJoint : public ScrewJointBase {
    * @param[in] axis          joint axis expressed in joint frame
    * @param[in] thread_pitch  joint's thread pitch in dist per rev
    */
-  ScrewJoint(uint8_t id, const std::string &name, const gtsam::Pose3 &wTj,
+  ScrewJoint(uint8_t id, const std::string &name,
              const LinkSharedPtr &parent_link, const LinkSharedPtr &child_link,
-             const JointParams &parameters, const gtsam::Vector3 &axis,
-             double thread_pitch)
-      : ScrewJointBase(id, name, wTj, parent_link, child_link, parameters, axis,
-                       getScrewAxis(axis, thread_pitch)) {}
+             const gtsam::Vector3 &axis, double thread_pitch,
+             const JointParams &parameters = JointParams(),
+             const gtsam::Pose3 &wTj = gtsam::Pose3())
+      : ScrewJointBase(id, name, parent_link, child_link, axis,
+                       getScrewAxis(axis, thread_pitch), parameters, wTj) {}
 
   /// Return joint type for use in reconstructing robot from JointParams.
   Type type() const override { return Type::Screw; }

--- a/gtdynamics/universal_robot/ScrewJoint.h
+++ b/gtdynamics/universal_robot/ScrewJoint.h
@@ -49,17 +49,16 @@ class ScrewJoint : public ScrewJointBase {
    * @param[in] wTj           joint pose expressed in world frame
    * @param[in] parent_link   Shared pointer to the parent Link.
    * @param[in] child_link    Shared pointer to the child Link.
-   * @param[in] parameters    JointParams struct
    * @param[in] axis          joint axis expressed in joint frame
    * @param[in] thread_pitch  joint's thread pitch in dist per rev
+   * @param[in] parameters    JointParams struct.
    */
-  ScrewJoint(uint8_t id, const std::string &name,
+  ScrewJoint(uint8_t id, const std::string &name, const gtsam::Pose3 &wTj,
              const LinkSharedPtr &parent_link, const LinkSharedPtr &child_link,
              const gtsam::Vector3 &axis, double thread_pitch,
-             const JointParams &parameters = JointParams(),
-             const gtsam::Pose3 &wTj = gtsam::Pose3())
-      : ScrewJointBase(id, name, parent_link, child_link, axis,
-                       getScrewAxis(axis, thread_pitch), parameters, wTj) {}
+             const JointParams &parameters = JointParams())
+      : ScrewJointBase(id, name, wTj, parent_link, child_link, axis,
+                       getScrewAxis(axis, thread_pitch), parameters) {}
 
   /// Return joint type for use in reconstructing robot from JointParams.
   Type type() const override { return Type::Screw; }

--- a/gtdynamics/universal_robot/ScrewJointBase.h
+++ b/gtdynamics/universal_robot/ScrewJointBase.h
@@ -70,13 +70,12 @@ class ScrewJointBase : public JointTyped {
    * Constructor using JointParams, joint name, wTj, screw axes,
    * and parent and child links.
    */
-  ScrewJointBase(uint8_t id, const std::string &name,
+  ScrewJointBase(uint8_t id, const std::string &name, const Pose3 &wTj,
                  const LinkSharedPtr &parent_link,
                  const LinkSharedPtr &child_link, const gtsam::Vector3 &axis,
                  const Vector6 &jScrewAxis,
-                 const JointParams &parameters = JointParams(),
-                 const Pose3 &wTj = gtsam::Pose3())
-      : JointTyped(id, name, parent_link, child_link, parameters, wTj),
+                 const JointParams &parameters = JointParams())
+      : JointTyped(id, name, wTj, parent_link, child_link, parameters),
         axis_(axis),
         pScrewAxis_(-jTpcom_.inverse().AdjointMap() * jScrewAxis),
         cScrewAxis_(jTccom_.inverse().AdjointMap() * jScrewAxis) {}

--- a/gtdynamics/universal_robot/ScrewJointBase.h
+++ b/gtdynamics/universal_robot/ScrewJointBase.h
@@ -70,11 +70,13 @@ class ScrewJointBase : public JointTyped {
    * Constructor using JointParams, joint name, wTj, screw axes,
    * and parent and child links.
    */
-  ScrewJointBase(uint8_t id, const std::string &name, const Pose3 &wTj,
+  ScrewJointBase(uint8_t id, const std::string &name,
                  const LinkSharedPtr &parent_link,
-                 const LinkSharedPtr &child_link, const JointParams &parameters,
-                 const gtsam::Vector3 &axis, const Vector6 &jScrewAxis)
-      : JointTyped(id, name, wTj, parent_link, child_link, parameters),
+                 const LinkSharedPtr &child_link, const gtsam::Vector3 &axis,
+                 const Vector6 &jScrewAxis,
+                 const JointParams &parameters = JointParams(),
+                 const Pose3 &wTj = gtsam::Pose3())
+      : JointTyped(id, name, parent_link, child_link, parameters, wTj),
         axis_(axis),
         pScrewAxis_(-jTpcom_.inverse().AdjointMap() * jScrewAxis),
         cScrewAxis_(jTccom_.inverse().AdjointMap() * jScrewAxis) {}

--- a/gtdynamics/universal_robot/sdf.cpp
+++ b/gtdynamics/universal_robot/sdf.cpp
@@ -127,17 +127,17 @@ JointSharedPtr JointFromSdf(uint8_t id, const LinkSharedPtr &parent_link,
   const gtsam::Vector3 axis = GetSdfAxis(sdf_joint);
   switch (sdf_joint.Type()) {
     case sdf::JointType::PRISMATIC:
-      joint = boost::make_shared<PrismaticJoint>(id, name, wTj, parent_link,
-                                                 child_link, parameters, axis);
+      joint = boost::make_shared<PrismaticJoint>(
+          id, name, parent_link, child_link, axis, parameters, wTj);
       break;
     case sdf::JointType::REVOLUTE:
-      joint = boost::make_shared<RevoluteJoint>(id, name, wTj, parent_link,
-                                                child_link, parameters, axis);
+      joint = boost::make_shared<RevoluteJoint>(
+          id, name, parent_link, child_link, axis, parameters, wTj);
       break;
     case sdf::JointType::SCREW:
-      joint = boost::make_shared<ScrewJoint>(id, name, wTj, parent_link,
-                                             child_link, parameters, axis,
-                                             sdf_joint.ThreadPitch());
+      joint = boost::make_shared<ScrewJoint>(id, name, parent_link, child_link,
+                                             axis, sdf_joint.ThreadPitch(),
+                                             parameters, wTj);
       break;
     default:
       throw std::runtime_error("Joint type for [" + name +

--- a/gtdynamics/universal_robot/sdf.cpp
+++ b/gtdynamics/universal_robot/sdf.cpp
@@ -159,17 +159,17 @@ JointSharedPtr JointFromSdf(uint8_t id, const LinkSharedPtr &parent_link,
   const gtsam::Vector3 axis = GetSdfAxis(sdf_joint);
   switch (sdf_joint.Type()) {
     case sdf::JointType::PRISMATIC:
-      joint = boost::make_shared<PrismaticJoint>(
-          id, name, parent_link, child_link, axis, parameters, wTj);
+      joint = boost::make_shared<PrismaticJoint>(id, name, wTj, parent_link,
+                                                 child_link, axis, parameters);
       break;
     case sdf::JointType::REVOLUTE:
-      joint = boost::make_shared<RevoluteJoint>(
-          id, name, parent_link, child_link, axis, parameters, wTj);
+      joint = boost::make_shared<RevoluteJoint>(id, name, wTj, parent_link,
+                                                child_link, axis, parameters);
       break;
     case sdf::JointType::SCREW:
-      joint = boost::make_shared<ScrewJoint>(id, name, parent_link, child_link,
-                                             axis, sdf_joint.ThreadPitch(),
-                                             parameters, wTj);
+      joint = boost::make_shared<ScrewJoint>(
+          id, name, wTj, parent_link, child_link, axis, sdf_joint.ThreadPitch(),
+          parameters);
       break;
     default:
       throw std::runtime_error("Joint type for [" + name +

--- a/python/tests/test_four_bar.py
+++ b/python/tests/test_four_bar.py
@@ -48,14 +48,14 @@ class TestFourBar(unittest.TestCase):
         j3_pose = Pose3(Rot3.Rz(0), (0, 2, 0))
         j4_pose = Pose3(Rot3.Rz(0), (0, 0, 0))
 
-        joint1 = gtd.RevoluteJoint(1, "j1", j1_pose, link1, link2, params,
-                                   axis)
-        joint2 = gtd.RevoluteJoint(2, "j2", j2_pose, link2, link3, params,
-                                   axis)
-        joint3 = gtd.RevoluteJoint(3, "j3", j3_pose, link3, link4, params,
-                                   axis)
-        joint4 = gtd.RevoluteJoint(4, "j4", j4_pose, link4, link1, params,
-                                   axis)
+        joint1 = gtd.RevoluteJoint(1, "j1", link1, link2, axis, params,
+                                   j1_pose)
+        joint2 = gtd.RevoluteJoint(2, "j2", link2, link3, axis, params,
+                                   j2_pose)
+        joint3 = gtd.RevoluteJoint(3, "j3", link3, link4, axis, params,
+                                   j3_pose)
+        joint4 = gtd.RevoluteJoint(4, "j4", link4, link1, axis, params,
+                                   j4_pose)
         joints = {"j1": joint1, "j2": joint2, "j3": joint3, "j4": joint4}
 
         # connect links to joints
@@ -86,8 +86,9 @@ class TestFourBar(unittest.TestCase):
         torques = np.array([1, 0, 0, 0])
         for idx, joint in enumerate(robot.joints()):
             gtd.InsertJointAngleDouble(known_values, joint.id(), 0,
-                                 joint_angles[idx])
-            gtd.InsertJointVelDouble(known_values, joint.id(), 0, joint_vels[idx])
+                                       joint_angles[idx])
+            gtd.InsertJointVelDouble(known_values, joint.id(), 0,
+                                     joint_vels[idx])
             gtd.InsertTorqueDouble(known_values, joint.id(), 0, torques[idx])
 
         prior_graph = graph_builder.forwardDynamicsPriors(

--- a/python/tests/test_four_bar.py
+++ b/python/tests/test_four_bar.py
@@ -14,8 +14,8 @@
 import unittest
 
 import gtsam
-from gtsam import Pose3, Rot3
 import numpy as np
+from gtsam import Pose3, Rot3
 
 import gtdynamics as gtd
 

--- a/python/tests/test_four_bar.py
+++ b/python/tests/test_four_bar.py
@@ -48,14 +48,14 @@ class TestFourBar(unittest.TestCase):
         j3_pose = Pose3(Rot3.Rz(0), (0, 2, 0))
         j4_pose = Pose3(Rot3.Rz(0), (0, 0, 0))
 
-        joint1 = gtd.RevoluteJoint(1, "j1", link1, link2, axis, params,
-                                   j1_pose)
-        joint2 = gtd.RevoluteJoint(2, "j2", link2, link3, axis, params,
-                                   j2_pose)
-        joint3 = gtd.RevoluteJoint(3, "j3", link3, link4, axis, params,
-                                   j3_pose)
-        joint4 = gtd.RevoluteJoint(4, "j4", link4, link1, axis, params,
-                                   j4_pose)
+        joint1 = gtd.RevoluteJoint(1, "j1", j1_pose, link1, link2, axis,
+                                   params)
+        joint2 = gtd.RevoluteJoint(2, "j2", j2_pose, link2, link3, axis,
+                                   params)
+        joint3 = gtd.RevoluteJoint(3, "j3", j3_pose, link3, link4, axis,
+                                   params)
+        joint4 = gtd.RevoluteJoint(4, "j4", j4_pose, link4, link1, axis,
+                                   params)
         joints = {"j1": joint1, "j2": joint2, "j3": joint3, "j4": joint4}
 
         # connect links to joints

--- a/tests/make_joint.h
+++ b/tests/make_joint.h
@@ -41,6 +41,6 @@ boost::shared_ptr<const ScrewJointBase> make_joint(gtsam::Pose3 cMp,
   gtsam::Vector6 jScrewAxis = jTccom.AdjointMap() * cScrewAxis;
 
   return boost::make_shared<const ScrewJointBase>(ScrewJointBase(
-      1, "j1", wTj, l1, l2, joint_params, jScrewAxis.head<3>(), jScrewAxis));
+      1, "j1", l1, l2, jScrewAxis.head<3>(), jScrewAxis, joint_params, wTj));
 }
 }  // namespace gtdynamics

--- a/tests/make_joint.h
+++ b/tests/make_joint.h
@@ -26,7 +26,7 @@ boost::shared_ptr<const ScrewJointBase> make_joint(gtsam::Pose3 cMp,
   gtsam::Matrix3 inertia = gtsam::Vector3(3, 2, 1).asDiagonal();
   gtsam::Pose3 wTl, lTcom;
 
-  auto l1 = boost::make_shared<Link>(Link(1, name, mass, inertia, wTl, lTcom));
+  auto l1 = boost::make_shared<Link>(Link(1, name, mass, inertia, lTcom));
   auto l2 = boost::make_shared<Link>(
       Link(2, name, mass, inertia, cMp.inverse(), lTcom));
 
@@ -43,4 +43,4 @@ boost::shared_ptr<const ScrewJointBase> make_joint(gtsam::Pose3 cMp,
   return boost::make_shared<const ScrewJointBase>(ScrewJointBase(
       1, "j1", wTj, l1, l2, joint_params, jScrewAxis.head<3>(), jScrewAxis));
 }
-} // namespace gtdynamics
+}  // namespace gtdynamics

--- a/tests/make_joint.h
+++ b/tests/make_joint.h
@@ -26,7 +26,7 @@ boost::shared_ptr<const ScrewJointBase> make_joint(gtsam::Pose3 cMp,
   gtsam::Matrix3 inertia = gtsam::Vector3(3, 2, 1).asDiagonal();
   gtsam::Pose3 wTl, lTcom;
 
-  auto l1 = boost::make_shared<Link>(Link(1, name, mass, inertia, lTcom));
+  auto l1 = boost::make_shared<Link>(Link(1, name, mass, inertia, wTl, lTcom));
   auto l2 = boost::make_shared<Link>(
       Link(2, name, mass, inertia, cMp.inverse(), lTcom));
 
@@ -41,6 +41,6 @@ boost::shared_ptr<const ScrewJointBase> make_joint(gtsam::Pose3 cMp,
   gtsam::Vector6 jScrewAxis = jTccom.AdjointMap() * cScrewAxis;
 
   return boost::make_shared<const ScrewJointBase>(ScrewJointBase(
-      1, "j1", l1, l2, jScrewAxis.head<3>(), jScrewAxis, joint_params, wTj));
+      1, "j1", wTj, l1, l2, jScrewAxis.head<3>(), jScrewAxis, joint_params));
 }
 }  // namespace gtdynamics

--- a/tests/testLink.cpp
+++ b/tests/testLink.cpp
@@ -29,7 +29,7 @@ using gtsam::Rot3;
 
 // Construct the same link via Params and ensure all values are as expected.
 TEST(Link, params_constructor) {
-  Link l1(1, "l1", 100.0, gtsam::Vector3(3, 2, 1).asDiagonal(),
+  Link l1(1, "l1", 100.0, gtsam::Vector3(3, 2, 1).asDiagonal(), Pose3(),
           Pose3(Rot3(), Point3(0, 0, 1)));
 
   // name
@@ -68,8 +68,8 @@ TEST(Link, NumJoints) {
   EXPECT_LONGS_EQUAL(1, l1->numJoints());
 
   auto j2 = boost::make_shared<RevoluteJoint>(
-      123, "j2", l1, l2, gtsam::Vector3(1, 0, 0), JointParams(),
-      Pose3(Rot3(), Point3(0, 0.5, 2)));
+      123, "j2", Pose3(Rot3(), Point3(0, 0.5, 2)), l1, l2,
+      gtsam::Vector3(1, 0, 0), JointParams());
 
   l1->addJoint(j2);
   EXPECT_LONGS_EQUAL(2, l1->numJoints());

--- a/tests/testLink.cpp
+++ b/tests/testLink.cpp
@@ -29,7 +29,7 @@ using gtsam::Rot3;
 
 // Construct the same link via Params and ensure all values are as expected.
 TEST(Link, params_constructor) {
-  Link l1(1, "l1", 100.0, gtsam::Vector3(3, 2, 1).asDiagonal(), Pose3(),
+  Link l1(1, "l1", 100.0, gtsam::Vector3(3, 2, 1).asDiagonal(),
           Pose3(Rot3(), Point3(0, 0, 1)));
 
   // name

--- a/tests/testLink.cpp
+++ b/tests/testLink.cpp
@@ -68,8 +68,8 @@ TEST(Link, NumJoints) {
   EXPECT_LONGS_EQUAL(1, l1->numJoints());
 
   auto j2 = boost::make_shared<RevoluteJoint>(
-      123, "j2", Pose3(Rot3(), Point3(0, 0.5, 2)), l1, l2, JointParams(),
-      gtsam::Vector3(1, 0, 0));
+      123, "j2", l1, l2, gtsam::Vector3(1, 0, 0), JointParams(),
+      Pose3(Rot3(), Point3(0, 0.5, 2)));
 
   l1->addJoint(j2);
   EXPECT_LONGS_EQUAL(2, l1->numJoints());

--- a/tests/testPrismaticJoint.cpp
+++ b/tests/testPrismaticJoint.cpp
@@ -42,8 +42,8 @@ TEST(Joint, params_constructor_prismatic) {
   const gtsam::Vector3 j1_axis = (gtsam::Vector(3) << 0, 0, 1).finished();
 
   auto j1 = boost::make_shared<PrismaticJoint>(
-      1, "j1", l1, l2, j1_axis, parameters,
-      Pose3(Rot3::Rx(1.5707963268), Point3(0, 0, 2)));
+      1, "j1", Pose3(Rot3::Rx(1.5707963268), Point3(0, 0, 2)), l1, l2, j1_axis,
+      parameters);
 
   // get shared ptr
   EXPECT(j1->shared() == j1);

--- a/tests/testPrismaticJoint.cpp
+++ b/tests/testPrismaticJoint.cpp
@@ -42,8 +42,8 @@ TEST(Joint, params_constructor_prismatic) {
   const gtsam::Vector3 j1_axis = (gtsam::Vector(3) << 0, 0, 1).finished();
 
   auto j1 = boost::make_shared<PrismaticJoint>(
-      1, "j1", Pose3(Rot3::Rx(1.5707963268), Point3(0, 0, 2)), l1, l2,
-      parameters, j1_axis);
+      1, "j1", l1, l2, j1_axis, parameters,
+      Pose3(Rot3::Rx(1.5707963268), Point3(0, 0, 2)));
 
   // get shared ptr
   EXPECT(j1->shared() == j1);

--- a/tests/testRevoluteJoint.cpp
+++ b/tests/testRevoluteJoint.cpp
@@ -55,8 +55,8 @@ TEST(Joint, params_constructor) {
 
   const Vector3 axis = (Vector(3) << 1, 0, 0).finished();
 
-  RevoluteJoint j1(1, "j1", l1, l2, axis, parameters,
-                   Pose3(Rot3(), Point3(0, 0, 2)));
+  RevoluteJoint j1(1, "j1", Pose3(Rot3(), Point3(0, 0, 2)), l1, l2, axis,
+                   parameters);
 
   // name
   EXPECT(assert_equal(j1.name(), "j1"));

--- a/tests/testRevoluteJoint.cpp
+++ b/tests/testRevoluteJoint.cpp
@@ -55,8 +55,8 @@ TEST(Joint, params_constructor) {
 
   const Vector3 axis = (Vector(3) << 1, 0, 0).finished();
 
-  RevoluteJoint j1(1, "j1", Pose3(Rot3(), Point3(0, 0, 2)), l1, l2, parameters,
-                   axis);
+  RevoluteJoint j1(1, "j1", l1, l2, axis, parameters,
+                   Pose3(Rot3(), Point3(0, 0, 2)));
 
   // name
   EXPECT(assert_equal(j1.name(), "j1"));

--- a/tests/testScrewJoint.cpp
+++ b/tests/testScrewJoint.cpp
@@ -41,8 +41,8 @@ TEST(Joint, params_constructor) {
   parameters.scalar_limits.value_limit_threshold = 0;
 
   auto j1 = boost::make_shared<ScrewJoint>(
-      123, "j1", l1, l2, gtsam::Vector3(1, 0, 0), 0.5, parameters,
-      Pose3(Rot3(), Point3(0, 0, 2)));
+      123, "j1", Pose3(Rot3(), Point3(0, 0, 2)), l1, l2,
+      gtsam::Vector3(1, 0, 0), 0.5, parameters);
 
   // name
   EXPECT(assert_equal(j1->name(), "j1"));

--- a/tests/testScrewJoint.cpp
+++ b/tests/testScrewJoint.cpp
@@ -41,8 +41,8 @@ TEST(Joint, params_constructor) {
   parameters.scalar_limits.value_limit_threshold = 0;
 
   auto j1 = boost::make_shared<ScrewJoint>(
-      123, "j1", Pose3(Rot3(), Point3(0, 0, 2)), l1, l2, parameters,
-      gtsam::Vector3(1, 0, 0), 0.5);
+      123, "j1", l1, l2, gtsam::Vector3(1, 0, 0), 0.5, parameters,
+      Pose3(Rot3(), Point3(0, 0, 2)));
 
   // name
   EXPECT(assert_equal(j1->name(), "j1"));

--- a/tests/testSdf.cpp
+++ b/tests/testSdf.cpp
@@ -117,8 +117,7 @@ TEST(File, parameters_from_file) {
   EXPECT(assert_equal(300, joint_1_parameters.torque_limit));
 
   // Test for reading parameters (joint limits) from spider.sdf.
-  auto spider_sdf =
-      GetSdf(kSdfPath + std::string("/spider.sdf"), "spider");
+  auto spider_sdf = GetSdf(kSdfPath + std::string("/spider.sdf"), "spider");
   auto knee_1_parameters =
       ParametersFromSdfJoint(*spider_sdf.JointByName("knee_1"));
 
@@ -184,8 +183,8 @@ TEST(Link, urdf_constructor_link) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
   // Test constructor.
-  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", wTj, l1, l2,
-                                              j1_parameters, j1_axis);
+  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", l1, l2, j1_axis,
+                                              j1_parameters, wTj);
 
   // get shared ptr
   EXPECT(l1->shared() == l1);
@@ -246,8 +245,8 @@ TEST(Joint, urdf_constructor_revolute) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
   // Test constructor.
-  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", j1_wTj, l1, l2,
-                                              j1_parameters, j1_axis);
+  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", l1, l2, j1_axis,
+                                              j1_parameters, j1_wTj);
 
   // get shared ptr
   EXPECT(j1->shared() == j1);
@@ -321,8 +320,8 @@ TEST(Joint, sdf_constructor_revolute) {
   // constructor for j1
   JointParams j1_parameters;
   j1_parameters.effort_type = JointEffortType::Actuated;
-  auto j1 = boost::make_shared<RevoluteJoint>(1, "joint_1", j1_wTj, l0, l1,
-                                              j1_parameters, j1_axis);
+  auto j1 = boost::make_shared<RevoluteJoint>(1, "joint_1", l0, l1, j1_axis,
+                                              j1_parameters, j1_wTj);
 
   // check screw axis
   gtsam::Vector6 screw_axis_j1_l0, screw_axis_j1_l1;
@@ -347,8 +346,8 @@ TEST(Joint, sdf_constructor_revolute) {
   Pose3 j2_wTj = GetJointFrame(*model.JointByName("joint_2"), l1, l2);
   const gtsam::Vector3 j2_axis = GetSdfAxis(*model.JointByName("joint_2"));
 
-  auto j2 = boost::make_shared<RevoluteJoint>(2, "joint_2", j2_wTj, l1, l2,
-                                              j2_parameters, j2_axis);
+  auto j2 = boost::make_shared<RevoluteJoint>(2, "joint_2", l1, l2, j2_axis,
+                                              j2_parameters, j2_wTj);
 
   // check screw axis
   gtsam::Vector6 screw_axis_j2_l1, screw_axis_j2_l2;
@@ -379,8 +378,8 @@ TEST(Joint, limit_params) {
   Pose3 j1_wTj = GetJointFrame(*model.JointByName("j1"), l1, l2);
   const gtsam::Vector3 j1_axis = GetSdfAxis(*model.JointByName("j1"));
 
-  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", j1_wTj, l1, l2,
-                                              j1_parameters, j1_axis);
+  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", l1, l2, j1_axis,
+                                              j1_parameters, j1_wTj);
 
   EXPECT(assert_equal(-1.57, j1->parameters().scalar_limits.value_lower_limit));
   EXPECT(assert_equal(1.57, j1->parameters().scalar_limits.value_upper_limit));
@@ -403,8 +402,8 @@ TEST(Joint, limit_params) {
       GetSdfAxis(*model2.JointByName("joint_1"));
 
   auto joint_1 = boost::make_shared<RevoluteJoint>(
-      1, "joint_1", joint_1_wTj, link_0, link_1, joint_1_parameters,
-      joint_1_axis);
+      1, "joint_1", link_0, link_1, joint_1_axis, joint_1_parameters,
+      joint_1_wTj);
 
   EXPECT(assert_equal(-1e16,
                       joint_1->parameters().scalar_limits.value_lower_limit));
@@ -435,8 +434,8 @@ TEST(Joint, urdf_constructor_prismatic) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
   // Test constructor.
-  auto j1 = boost::make_shared<PrismaticJoint>(1, "j1", wTj, l1, l2,
-                                               j1_parameters, j1_axis);
+  auto j1 = boost::make_shared<PrismaticJoint>(1, "j1", l1, l2, j1_axis,
+                                               j1_parameters, wTj);
 
   // get shared ptr
   EXPECT(j1->shared() == j1);
@@ -511,8 +510,8 @@ TEST(Joint, sdf_constructor_screw) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*model.JointByName("joint_1"));
 
   auto j1 = boost::make_shared<ScrewJoint>(
-      1, "joint_1", wTj, l0, l1, j1_parameters, j1_axis,
-      model.JointByName("joint_1")->ThreadPitch());
+      1, "joint_1", l0, l1, j1_axis,
+      model.JointByName("joint_1")->ThreadPitch(), j1_parameters, wTj);
 
   // expected values for screw about z axis
   // check screw axis
@@ -545,8 +544,8 @@ TEST(Robot, simple_urdf) {
   Pose3 wTj = GetJointFrame(*simple_urdf.JointByName("j1"), l1, l2);
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
-  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", wTj, l1, l2,
-                                              j1_parameters, j1_axis);
+  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", l1, l2, j1_axis,
+                                              j1_parameters, wTj);
 
   // Initialize Robot instance.
   auto simple_robot =

--- a/tests/testSdf.cpp
+++ b/tests/testSdf.cpp
@@ -183,8 +183,8 @@ TEST(Sdf, urdf_constructor_link) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
   // Test constructor.
-  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", l1, l2, j1_axis,
-                                              j1_parameters, wTj);
+  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", wTj, l1, l2, j1_axis,
+                                              j1_parameters);
 
   // get shared ptr
   EXPECT(l1->shared() == l1);
@@ -245,8 +245,8 @@ TEST(Sdf, urdf_constructor_revolute) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
   // Test constructor.
-  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", l1, l2, j1_axis,
-                                              j1_parameters, j1_wTj);
+  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", j1_wTj, l1, l2, j1_axis,
+                                              j1_parameters);
 
   // get shared ptr
   EXPECT(j1->shared() == j1);
@@ -320,8 +320,8 @@ TEST(Sdf, sdf_constructor_revolute) {
   // constructor for j1
   JointParams j1_parameters;
   j1_parameters.effort_type = JointEffortType::Actuated;
-  auto j1 = boost::make_shared<RevoluteJoint>(1, "joint_1", l0, l1, j1_axis,
-                                              j1_parameters, j1_wTj);
+  auto j1 = boost::make_shared<RevoluteJoint>(1, "joint_1", j1_wTj, l0, l1,
+                                              j1_axis, j1_parameters);
 
   // check screw axis
   gtsam::Vector6 screw_axis_j1_l0, screw_axis_j1_l1;
@@ -346,8 +346,8 @@ TEST(Sdf, sdf_constructor_revolute) {
   Pose3 j2_wTj = GetJointFrame(*model.JointByName("joint_2"), l1, l2);
   const gtsam::Vector3 j2_axis = GetSdfAxis(*model.JointByName("joint_2"));
 
-  auto j2 = boost::make_shared<RevoluteJoint>(2, "joint_2", l1, l2, j2_axis,
-                                              j2_parameters, j2_wTj);
+  auto j2 = boost::make_shared<RevoluteJoint>(2, "joint_2", j2_wTj, l1, l2,
+                                              j2_axis, j2_parameters);
 
   // check screw axis
   gtsam::Vector6 screw_axis_j2_l1, screw_axis_j2_l2;
@@ -378,8 +378,8 @@ TEST(Sdf, limit_params) {
   Pose3 j1_wTj = GetJointFrame(*model.JointByName("j1"), l1, l2);
   const gtsam::Vector3 j1_axis = GetSdfAxis(*model.JointByName("j1"));
 
-  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", l1, l2, j1_axis,
-                                              j1_parameters, j1_wTj);
+  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", j1_wTj, l1, l2, j1_axis,
+                                              j1_parameters);
 
   EXPECT(assert_equal(-1.57, j1->parameters().scalar_limits.value_lower_limit));
   EXPECT(assert_equal(1.57, j1->parameters().scalar_limits.value_upper_limit));
@@ -401,9 +401,9 @@ TEST(Sdf, limit_params) {
   const gtsam::Vector3 joint_1_axis =
       GetSdfAxis(*model2.JointByName("joint_1"));
 
-  auto joint_1 = boost::make_shared<RevoluteJoint>(
-      1, "joint_1", link_0, link_1, joint_1_axis, joint_1_parameters,
-      joint_1_wTj);
+  auto joint_1 = boost::make_shared<RevoluteJoint>(1, "joint_1", joint_1_wTj,
+                                                   link_0, link_1, joint_1_axis,
+                                                   joint_1_parameters);
 
   EXPECT(assert_equal(-1e16,
                       joint_1->parameters().scalar_limits.value_lower_limit));
@@ -434,8 +434,8 @@ TEST(Sdf, urdf_constructor_prismatic) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
   // Test constructor.
-  auto j1 = boost::make_shared<PrismaticJoint>(1, "j1", l1, l2, j1_axis,
-                                               j1_parameters, wTj);
+  auto j1 = boost::make_shared<PrismaticJoint>(1, "j1", wTj, l1, l2, j1_axis,
+                                               j1_parameters);
 
   // get shared ptr
   EXPECT(j1->shared() == j1);
@@ -510,8 +510,8 @@ TEST(Sdf, sdf_constructor_screw) {
   const gtsam::Vector3 j1_axis = GetSdfAxis(*model.JointByName("joint_1"));
 
   auto j1 = boost::make_shared<ScrewJoint>(
-      1, "joint_1", l0, l1, j1_axis,
-      model.JointByName("joint_1")->ThreadPitch(), j1_parameters, wTj);
+      1, "joint_1", wTj, l0, l1, j1_axis,
+      model.JointByName("joint_1")->ThreadPitch(), j1_parameters);
 
   // expected values for screw about z axis
   // check screw axis
@@ -544,8 +544,8 @@ TEST(Robot, simple_urdf) {
   Pose3 wTj = GetJointFrame(*simple_urdf.JointByName("j1"), l1, l2);
   const gtsam::Vector3 j1_axis = GetSdfAxis(*simple_urdf.JointByName("j1"));
 
-  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", l1, l2, j1_axis,
-                                              j1_parameters, wTj);
+  auto j1 = boost::make_shared<RevoluteJoint>(1, "j1", wTj, l1, l2, j1_axis,
+                                              j1_parameters);
 
   // Initialize Robot instance.
   auto simple_robot =

--- a/tests/testStaticsSlice.cpp
+++ b/tests/testStaticsSlice.cpp
@@ -41,22 +41,15 @@ TEST(Statics, OneMovingLink) {
                       Fg_B, kTol));
 
   // Create base and link
-  // TODO(frank): #207 should not have to provide wTl to Link constructor
   const Pose3 lTcom(Rot3(), Point3(L / 2, 0, 0));
   const auto I3 = Matrix3::Identity();  // inertia
-  auto base =
-      boost::make_shared<Link>(0, "base", 1e10, I3, Pose3(), Pose3(), true);
+  auto base = boost::make_shared<Link>(0, "base", 1e10, I3, Pose3(), true);
   auto link = boost::make_shared<Link>(1, "link", 1.0, I3, lTcom);
 
   // Create joint
   constexpr unsigned char id = 22;
-  // TODO(frank): #206 should not have to provide wTj to the joint constructor.
-  const Pose3 wTj;
-  // TODO(frank): #205 make JointParams last argument and provide default
-  const JointParams jointParams;
   const Vector3 axis(0, 0, 1);
-  auto joint = boost::make_shared<RevoluteJoint>(id, "joint1", wTj, base, link,
-                                                 jointParams, axis);
+  auto joint = boost::make_shared<RevoluteJoint>(id, "joint1", base, link, axis);
 
   // Create mechanism.
   // TODO(frank): specifying name is redundant and failure prone!

--- a/tests/testStaticsSlice.cpp
+++ b/tests/testStaticsSlice.cpp
@@ -42,12 +42,11 @@ TEST(Statics, OneMovingLink) {
 
   // Create base and link
   // TODO(frank): #207 should not have to provide wTl to Link constructor
-  const Pose3 wTl;  // we don't care!
   const Pose3 lTcom(Rot3(), Point3(L / 2, 0, 0));
   const auto I3 = Matrix3::Identity();  // inertia
   auto base =
       boost::make_shared<Link>(0, "base", 1e10, I3, Pose3(), Pose3(), true);
-  auto link = boost::make_shared<Link>(1, "link", 1.0, I3, wTl, lTcom);
+  auto link = boost::make_shared<Link>(1, "link", 1.0, I3, lTcom);
 
   // Create joint
   constexpr unsigned char id = 22;

--- a/tests/testStaticsSlice.cpp
+++ b/tests/testStaticsSlice.cpp
@@ -41,15 +41,21 @@ TEST(Statics, OneMovingLink) {
                       Fg_B, kTol));
 
   // Create base and link
+  // TODO(frank): #207 should not have to provide wTl to Link constructor
+  const Pose3 wTl;  // we don't care!
   const Pose3 lTcom(Rot3(), Point3(L / 2, 0, 0));
   const auto I3 = Matrix3::Identity();  // inertia
-  auto base = boost::make_shared<Link>(0, "base", 1e10, I3, Pose3(), true);
-  auto link = boost::make_shared<Link>(1, "link", 1.0, I3, lTcom);
+  auto base =
+      boost::make_shared<Link>(0, "base", 1e10, I3, Pose3(), Pose3(), true);
+  auto link = boost::make_shared<Link>(1, "link", 1.0, I3, wTl, lTcom);
 
   // Create joint
   constexpr unsigned char id = 22;
+  // TODO(frank): #206 should not have to provide wTj to the joint constructor.
+  const Pose3 wTj;
   const Vector3 axis(0, 0, 1);
-  auto joint = boost::make_shared<RevoluteJoint>(id, "joint1", base, link, axis);
+  auto joint =
+      boost::make_shared<RevoluteJoint>(id, "joint1", wTj, base, link, axis);
 
   // Create mechanism.
   // TODO(frank): specifying name is redundant and failure prone!
@@ -120,7 +126,7 @@ TEST(Statics, Quadruped) {
   // Solve for wrenches, with known kinematics
   auto result = statics.solve(slice, ik_solution);
   EXPECT_LONGS_EQUAL(61, result.size());
-  //TODO(Varun) Issue #233
+  // TODO(Varun) Issue #233
   // Regression
   // EXPECT_DOUBLES_EQUAL(0.0670426, Torque(result, 0, k), 1e-5);
 


### PR DESCRIPTION
Fixes #205 ~~, #206, and #207~~.

- Make wTl transform optional in Link constructor. Frank says: ???
- wTj optional in Joint constructor: Frank says: ???
- Make jointParams last argument and provide default.