### PR TITLE
Remove world language from joint

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -213,9 +213,8 @@ class JointParams {
 
 virtual class Joint {
   uint8_t id() const;
-  const gtsam::Pose3 &wTj() const;
   const gtsam::Pose3 &jMp() const;
-  const Pose3 &jMc() const;
+  const gtsam::Pose3 &jMc() const;
   string name() const;
   gtdynamics::Link* otherLink(const gtdynamics::Link* link);
   std::vector<gtdynamics::Link*> links() const;

--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -214,8 +214,8 @@ class JointParams {
 virtual class Joint {
   uint8_t id() const;
   const gtsam::Pose3 &wTj() const;
-  const gtsam::Pose3 &jTpcom() const;
-  const Pose3 &jTccom() const;
+  const gtsam::Pose3 &jMp() const;
+  const Pose3 &jMc() const;
   string name() const;
   gtdynamics::Link* otherLink(const gtdynamics::Link* link);
   std::vector<gtdynamics::Link*> links() const;

--- a/gtdynamics/universal_robot/Joint.cpp
+++ b/gtdynamics/universal_robot/Joint.cpp
@@ -34,7 +34,6 @@ Joint::Joint(uint8_t id, const std::string &name, const Pose3 &wTj,
       parameters_(parameters) {
   jMp_ = wTj_.inverse() * parent_link_->wTcom();
   jMc_ = wTj_.inverse() * child_link_->wTcom();
-  pMccom_ = parent_link_->wTcom().inverse() * child_link_->wTcom();
 }
 
 /* ************************************************************************* */

--- a/gtdynamics/universal_robot/Joint.cpp
+++ b/gtdynamics/universal_robot/Joint.cpp
@@ -28,12 +28,11 @@ Joint::Joint(uint8_t id, const std::string &name, const Pose3 &wTj,
              const JointParams &parameters)
     : id_(id),
       name_(name),
-      wTj_(wTj),
       parent_link_(parent_link),
       child_link_(child_link),
       parameters_(parameters) {
-  jMp_ = wTj_.inverse() * parent_link_->wTcom();
-  jMc_ = wTj_.inverse() * child_link_->wTcom();
+  jMp_ = wTj.inverse() * parent_link_->wTcom();
+  jMc_ = wTj.inverse() * child_link_->wTcom();
 }
 
 /* ************************************************************************* */

--- a/gtdynamics/universal_robot/Joint.cpp
+++ b/gtdynamics/universal_robot/Joint.cpp
@@ -32,8 +32,8 @@ Joint::Joint(uint8_t id, const std::string &name, const Pose3 &wTj,
       parent_link_(parent_link),
       child_link_(child_link),
       parameters_(parameters) {
-  jTpcom_ = wTj_.inverse() * parent_link_->wTcom();
-  jTccom_ = wTj_.inverse() * child_link_->wTcom();
+  jMp_ = wTj_.inverse() * parent_link_->wTcom();
+  jMc_ = wTj_.inverse() * child_link_->wTcom();
   pMccom_ = parent_link_->wTcom().inverse() * child_link_->wTcom();
 }
 

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -107,8 +107,6 @@ class Joint : public boost::enable_shared_from_this<Joint> {
   Pose3 jMp_;
   /// Rest transform to child link CoM frame from joint frame.
   Pose3 jMc_;
-  /// Transform to parent link com frame from child link com frame at rest.
-  Pose3 pMccom_;
 
   using LinkSharedPtr = boost::shared_ptr<Link>;
   LinkSharedPtr parent_link_;
@@ -188,10 +186,8 @@ class Joint : public boost::enable_shared_from_this<Joint> {
 
   bool operator==(const Joint &other) const {
     return (this->name_ == other.name_ && this->id_ == other.id_ &&
-            this->wTj_.equals(other.wTj_) &&
-            this->jMp_.equals(other.jMp_) &&
-            this->jMc_.equals(other.jMc_) &&
-            this->pMccom_.equals(other.pMccom_));
+            this->wTj_.equals(other.wTj_) && this->jMp_.equals(other.jMp_) &&
+            this->jMc_.equals(other.jMc_));
   }
 
   bool operator!=(const Joint &other) const { return !(*this == other); }

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -104,9 +104,9 @@ class Joint : public boost::enable_shared_from_this<Joint> {
   /// Joint frame defined in world frame.
   Pose3 wTj_;
   /// Rest transform to parent link CoM frame from joint frame.
-  Pose3 jTpcom_;
+  Pose3 jMp_;
   /// Rest transform to child link CoM frame from joint frame.
-  Pose3 jTccom_;
+  Pose3 jMc_;
   /// Transform to parent link com frame from child link com frame at rest.
   Pose3 pMccom_;
 
@@ -156,10 +156,10 @@ class Joint : public boost::enable_shared_from_this<Joint> {
   const Pose3 &wTj() const { return wTj_; }
 
   /// Transform from the joint frame to the parent's center of mass.
-  const Pose3 &jTpcom() const { return jTpcom_; }
+  const Pose3 &jMp() const { return jMp_; }
 
   /// Transform from the joint frame to the child's center of mass.
-  const Pose3 &jTccom() const { return jTccom_; }
+  const Pose3 &jMc() const { return jMc_; }
 
   /// Get a gtsam::Key for this joint
   gtsam::Key key() const { return gtsam::Key(id()); }
@@ -189,8 +189,8 @@ class Joint : public boost::enable_shared_from_this<Joint> {
   bool operator==(const Joint &other) const {
     return (this->name_ == other.name_ && this->id_ == other.id_ &&
             this->wTj_.equals(other.wTj_) &&
-            this->jTpcom_.equals(other.jTpcom_) &&
-            this->jTccom_.equals(other.jTccom_) &&
+            this->jMp_.equals(other.jMp_) &&
+            this->jMc_.equals(other.jMc_) &&
             this->pMccom_.equals(other.pMccom_));
   }
 

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -101,8 +101,6 @@ class Joint : public boost::enable_shared_from_this<Joint> {
   /// ID reference to DynamicsSymbol.
   uint8_t id_;
 
-  /// Joint frame defined in world frame.
-  Pose3 wTj_;
   /// Rest transform to parent link CoM frame from joint frame.
   Pose3 jMp_;
   /// Rest transform to child link CoM frame from joint frame.
@@ -150,9 +148,6 @@ class Joint : public boost::enable_shared_from_this<Joint> {
   /// Get the joint's ID.
   uint8_t id() const { return id_; }
 
-  /// Transform from the world frame to the joint frame.
-  const Pose3 &wTj() const { return wTj_; }
-
   /// Transform from the joint frame to the parent's center of mass.
   const Pose3 &jMp() const { return jMp_; }
 
@@ -186,8 +181,7 @@ class Joint : public boost::enable_shared_from_this<Joint> {
 
   bool operator==(const Joint &other) const {
     return (this->name_ == other.name_ && this->id_ == other.id_ &&
-            this->wTj_.equals(other.wTj_) && this->jMp_.equals(other.jMp_) &&
-            this->jMc_.equals(other.jMc_));
+            this->jMp_.equals(other.jMp_) && this->jMc_.equals(other.jMc_));
   }
 
   bool operator!=(const Joint &other) const { return !(*this == other); }

--- a/gtdynamics/universal_robot/ScrewJointBase.cpp
+++ b/gtdynamics/universal_robot/ScrewJointBase.cpp
@@ -40,15 +40,17 @@ namespace gtdynamics {
 Pose3 ScrewJointBase::parentTchild(
     double q,
     gtsam::OptionalJacobian<6, 1> pMc_H_q) const {
+  const Pose3 pMc = jMp_.inverse() * jMc_;
+
   if (pMc_H_q) {
     gtsam::Matrix6 exp_H_Sq;
     Vector6 Sq = cScrewAxis_ * q;
     Pose3 exp = Pose3::Expmap(Sq, exp_H_Sq);
-    Pose3 pMc = pMccom_.compose(exp);  // derivative in exp is identity!
+    Pose3 pTc = pMc * exp;  // derivative in exp is identity!
     *pMc_H_q = exp_H_Sq * cScrewAxis_;
-    return pMc;
+    return pTc;
   } else {
-    return pMccom_ * Pose3::Expmap(cScrewAxis_ * q);
+    return pMc * Pose3::Expmap(cScrewAxis_ * q);
   }
 }
 

--- a/gtdynamics/universal_robot/ScrewJointBase.cpp
+++ b/gtdynamics/universal_robot/ScrewJointBase.cpp
@@ -40,21 +40,20 @@ namespace gtdynamics {
 Pose3 ScrewJointBase::parentTchild(
     double q, gtsam::OptionalJacobian<6, 1> pMc_H_q) const {
   // Calculate pose of child in parent link, at rest.
-  // TODO(dellaert): store `pMj_` rather than `jMp_`
-  // NOTE(dellaert): Only if this is called more often than childTparent
+  // TODO(dellaert): store `pMj_` rather than `jMp_`.
+  // NOTE(dellaert): Only if this is called more often than childTparent.
   const Pose3 pMc = jMp_.inverse() * jMc_;
 
-  // Multiply screw axis with joint angle to get a finite 6D screw
+  // Multiply screw axis with joint angle to get a finite 6D screw.
   const Vector6 screw = cScrewAxis_ * q;
 
   // Calculate the actual relative pose taking into account the joint angle.
   // TODO(dellaert): use formula `pMj_ * screw_around_Z * jMc_`.
   if (pMc_H_q) {
-    gtsam::Matrix6 exp_H_Sq;
-    Pose3 exp = Pose3::Expmap(screw, exp_H_Sq);
-    Pose3 pTc = pMc * exp;  // derivative in exp is identity!
-    *pMc_H_q = exp_H_Sq * cScrewAxis_;
-    return pTc;
+    gtsam::Matrix6 exp_H_screw;
+    const Pose3 exp = Pose3::Expmap(screw, exp_H_screw);
+    *pMc_H_q = exp_H_screw * cScrewAxis_;
+    return pMc * exp;  // Note: derivative of compose in exp is identity.
   } else {
     return pMc * Pose3::Expmap(screw);
   }

--- a/gtdynamics/universal_robot/ScrewJointBase.h
+++ b/gtdynamics/universal_robot/ScrewJointBase.h
@@ -77,8 +77,8 @@ class ScrewJointBase : public JointTyped {
                  const JointParams &parameters = JointParams())
       : JointTyped(id, name, wTj, parent_link, child_link, parameters),
         axis_(axis),
-        pScrewAxis_(-jTpcom_.inverse().AdjointMap() * jScrewAxis),
-        cScrewAxis_(jTccom_.inverse().AdjointMap() * jScrewAxis) {}
+        pScrewAxis_(-jMp_.inverse().AdjointMap() * jScrewAxis),
+        cScrewAxis_(jMc_.inverse().AdjointMap() * jScrewAxis) {}
 
   /// Return joint type for use in reconstructing robot from JointParams.
   Type type() const override { return Type::ScrewAxis; }

--- a/tests/make_joint.h
+++ b/tests/make_joint.h
@@ -37,8 +37,8 @@ boost::shared_ptr<const ScrewJointBase> make_joint(gtsam::Pose3 cMp,
   joint_params.scalar_limits.value_upper_limit = 1.57;
   joint_params.scalar_limits.value_limit_threshold = 0;
   gtsam::Pose3 wTj = gtsam::Pose3(gtsam::Rot3(), gtsam::Point3(0, 0, 2));
-  gtsam::Pose3 jTccom = wTj.inverse() * l2->wTcom();
-  gtsam::Vector6 jScrewAxis = jTccom.AdjointMap() * cScrewAxis;
+  gtsam::Pose3 jMc = wTj.inverse() * l2->wTcom();
+  gtsam::Vector6 jScrewAxis = jMc.AdjointMap() * cScrewAxis;
 
   return boost::make_shared<const ScrewJointBase>(ScrewJointBase(
       1, "j1", wTj, l1, l2, jScrewAxis.head<3>(), jScrewAxis, joint_params));


### PR DESCRIPTION
Removed two poses that refer to world frame in favor of two remaining poses, that we (Dan and I) renamed to "M", signifying relative poses at rest.

Next steps:
- remove wTl and wTcom altogether in Link.h
- Use formula (6) to calculate parentTchild(), that's a change from variable screwAxis to a constant screwAxis
- get rid of cScrewAxis_ and pScrewAxis_ as they will no longer be used