### PR TITLE
removed robot_ and updated accordingly

### DIFF
--- a/gtdynamics/utils/Trajectory.cpp
+++ b/gtdynamics/utils/Trajectory.cpp
@@ -37,57 +37,58 @@ using std::vector;
 namespace gtdynamics {
 
 vector<NonlinearFactorGraph> Trajectory::getTransitionGraphs(
-    DynamicsGraph &graph_builder, double mu) const {
+    const Robot &robot, DynamicsGraph &graph_builder, double mu) const {
   vector<NonlinearFactorGraph> transition_graphs;
   vector<ContactPoints> trans_cps = transitionContactPoints();
   vector<int> final_timesteps = finalTimeSteps();
   for (int p = 1; p < numPhases(); p++) {
     transition_graphs.push_back(graph_builder.dynamicsFactorGraph(
-        robot_, final_timesteps[p - 1], trans_cps[p - 1], mu));
+        robot, final_timesteps[p - 1], trans_cps[p - 1], mu));
   }
   return transition_graphs;
 }
 
 NonlinearFactorGraph Trajectory::multiPhaseFactorGraph(
-    DynamicsGraph &graph_builder, const CollocationScheme collocation,
-    double mu) const {
+    const Robot& robot, DynamicsGraph &graph_builder,
+    const CollocationScheme collocation, double mu) const {
   // Graphs for transition between phases + their initial values.
-  auto transition_graphs = getTransitionGraphs(graph_builder, mu);
-  return graph_builder.multiPhaseTrajectoryFG(robot_, phaseDurations(),
+  auto transition_graphs = getTransitionGraphs(robot, graph_builder, mu);
+  return graph_builder.multiPhaseTrajectoryFG(robot, phaseDurations(),
                                               transition_graphs, collocation,
                                               phaseContactPoints(), mu);
 }
 
 vector<Values> Trajectory::transitionPhaseInitialValues(
-    double gaussian_noise) const {
+    const Robot &robot, double gaussian_noise) const {
   vector<ContactPoints> trans_cps = transitionContactPoints();
   vector<Values> transition_graph_init;
   vector<int> final_timesteps = finalTimeSteps();
   for (int p = 1; p < numPhases(); p++) {
     transition_graph_init.push_back(ZeroValues(
-        robot_, final_timesteps[p - 1], gaussian_noise, trans_cps[p - 1]));
+        robot, final_timesteps[p - 1], gaussian_noise, trans_cps[p - 1]));
   }
   return transition_graph_init;
 }
 
-Values Trajectory::multiPhaseInitialValues(double gaussian_noise,
+Values Trajectory::multiPhaseInitialValues(const Robot &robot,
+                                           double gaussian_noise,
                                            double dt) const {
   vector<Values> transition_graph_init =
-      transitionPhaseInitialValues(gaussian_noise);
-  return MultiPhaseZeroValuesTrajectory(robot_, phaseDurations(),
+      transitionPhaseInitialValues(robot, gaussian_noise);
+  return MultiPhaseZeroValuesTrajectory(robot, phaseDurations(),
                                         transition_graph_init, dt,
                                         gaussian_noise, phaseContactPoints());
 }
 
 NonlinearFactorGraph Trajectory::contactPointObjectives(
-    const SharedNoiseModel &cost_model, const Point3 &step,
-    const ContactAdjustments &contact_adjustments) const {
+    const Robot &robot, const SharedNoiseModel &cost_model,
+    const Point3 &step, const ContactAdjustments &contact_adjustments) const {
   NonlinearFactorGraph factors;
 
   // Initials contact point goal.
   // TODO(frank): #179 make sure height is handled correctly.
   ContactGoals cp_goals =
-      walk_cycle_.initContactPointGoal(contact_adjustments);
+      walk_cycle_.initContactPointGoal(robot, contact_adjustments);
 
   size_t k_start = 0;
   for (int w = 0; w < repeat_; w++) {
@@ -99,7 +100,8 @@ NonlinearFactorGraph Trajectory::contactPointObjectives(
 }
 
 void Trajectory::addBoundaryConditions(
-    gtsam::NonlinearFactorGraph *graph, const SharedNoiseModel &pose_model,
+    const Robot &robot, gtsam::NonlinearFactorGraph *graph,
+    const SharedNoiseModel &pose_model,
     const SharedNoiseModel &twist_model,
     const SharedNoiseModel &twist_acceleration_model,
     const SharedNoiseModel &joint_velocity_model,
@@ -108,7 +110,7 @@ void Trajectory::addBoundaryConditions(
   int K = getEndTimeStep(numPhases() - 1);
 
   // Add link boundary conditions to FG.
-  for (auto &&link : robot_.links()) {
+  for (auto &&link : robot.links()) {
     // Initial link pose, twists.
     graph->add(LinkObjectives(link->id(), 0)
                    .pose(link->wTcom(), pose_model)
@@ -121,17 +123,17 @@ void Trajectory::addBoundaryConditions(
   }
 
   // Add joint boundary conditions to FG.
-  graph->add(JointsAtRestObjectives(robot_, joint_velocity_model,
+  graph->add(JointsAtRestObjectives(robot, joint_velocity_model,
                                     joint_acceleration_model, 0));
-  graph->add(JointsAtRestObjectives(robot_, joint_velocity_model,
+  graph->add(JointsAtRestObjectives(robot, joint_velocity_model,
                                     joint_acceleration_model, K));
 }
 
 void Trajectory::addMinimumTorqueFactors(
-    gtsam::NonlinearFactorGraph *graph,
+    const Robot& robot, gtsam::NonlinearFactorGraph *graph,
     const SharedNoiseModel &cost_model) const {
   int K = getEndTimeStep(numPhases() - 1);
-  for (auto &&joint : robot_.joints()) {
+  for (auto &&joint : robot.joints()) {
     auto j = joint->id();
     for (int k = 0; k <= K; k++) {
       graph->emplace_shared<MinTorqueFactor>(internal::TorqueKey(j, k),
@@ -140,14 +142,15 @@ void Trajectory::addMinimumTorqueFactors(
   }
 }
 
-void Trajectory::writePhaseToFile(std::ofstream &file,
+void Trajectory::writePhaseToFile(const Robot &robot,
+                                  std::ofstream &file,
                                   const gtsam::Values &results, int p) const {
   using gtsam::Matrix;
 
-  // Extract joimt values.
+  // Extract joint values.
   int k = getStartTimeStep(p);
   Matrix mat =
-      phase(p).jointMatrix(results, k, results.atDouble(PhaseKey(p)));
+      phase(p).jointMatrix(robot, results, k, results.atDouble(PhaseKey(p)));
 
   // Write to file.
   const static Eigen::IOFormat CSVFormat(Eigen::StreamPrecision,
@@ -156,10 +159,11 @@ void Trajectory::writePhaseToFile(std::ofstream &file,
 }
 
 // Write results to traj file
-void Trajectory::writeToFile(const std::string &name,
+void Trajectory::writeToFile(const Robot &robot,
+                             const std::string &name,
                              const gtsam::Values &results) const {
   vector<string> jnames;
-  for (auto &&joint : robot_.joints()) {
+  for (auto &&joint : robot.joints()) {
     jnames.push_back(joint->name());
   }
   string jnames_str = boost::algorithm::join(jnames, ",");
@@ -169,11 +173,14 @@ void Trajectory::writeToFile(const std::string &name,
   // angles, vels, accels, torques, time.
   file << jnames_str << "," << jnames_str << "," << jnames_str << ","
        << jnames_str << ",t\n";
-  for (int p = 0; p < numPhases(); p++) writePhaseToFile(file, results, p);
-
+  for (int p = 0; p < numPhases(); p++) {
+    writePhaseToFile(robot, file, results, p);
+  }
   // Write the last 4 phases to disk n times
   for (int i = 0; i < 10; i++) {
-    for (int p = 4; p < numPhases(); p++) writePhaseToFile(file, results, p);
+    for (int p = 4; p < numPhases(); p++) {
+      writePhaseToFile(robot, file, results, p);
+    }
   }
 }
 }  // namespace gtdynamics

--- a/gtdynamics/utils/WalkCycle.cpp
+++ b/gtdynamics/utils/WalkCycle.cpp
@@ -42,7 +42,8 @@ bool hasPoint(const ContactGoals& cp_goals, const PointOnLink &contact_point) {
     return !(it == cp_goals.end());
 }
 
-ContactGoals WalkCycle::initContactPointGoal(const ContactAdjustments &contact_adjustments) const {
+ContactGoals WalkCycle::initContactPointGoal(
+  const Robot &robot, const ContactAdjustments &contact_adjustments) const {
   ContactGoals cp_goals;
 
   // Go over all phases, and all contact points
@@ -53,8 +54,7 @@ ContactGoals WalkCycle::initContactPointGoal(const ContactAdjustments &contact_a
         auto foot_w = kv.link->wTcom().transformFrom(kv.point);
 
         for (auto &&contact_adjustment : contact_adjustments) {
-          foot_w += phase.robotModel()
-                        .link(contact_adjustment.link_name)
+          foot_w += robot.link(contact_adjustment.link_name)
                         ->wTcom()
                         .transformFrom(contact_adjustment.adjustment);
         }

--- a/gtdynamics/utils/WalkCycle.h
+++ b/gtdynamics/utils/WalkCycle.h
@@ -77,13 +77,7 @@ class WalkCycle {
       if (link_count == 0)
         contact_points_.push_back(kv);
     }
-    
     phases_.push_back(phase);
-    if (phases_.size() > 0) {
-      if (!phases_[0].robotModel().isIdentical(phase.robotModel()))
-        throw std::runtime_error(
-            "This phase belongs to a different Robot model!");
-    }
   }
 
   /**
@@ -126,6 +120,7 @@ class WalkCycle {
    * @return Map from link name to goal points.
    */
   ContactGoals initContactPointGoal(
+      const Robot &robot,
       const ContactAdjustments &contact_adjustments = {}) const;
 
   /**

--- a/tests/testKinematicsPhase.cpp
+++ b/tests/testKinematicsPhase.cpp
@@ -29,7 +29,7 @@ TEST(Phase, InverseKinematics) {
   using namespace contact_goals_example;
 
   constexpr size_t num_time_steps = 5;
-  Phase phase0(robot, num_time_steps);
+  Phase phase0(num_time_steps);
   phase0.addContactPoint(LH, contact_in_com);
   phase0.addContactPoint(RF, contact_in_com);
 }

--- a/tests/testRobot.cpp
+++ b/tests/testRobot.cpp
@@ -72,21 +72,6 @@ TEST(Robot, simple_rr_sdf) {
   EXPECT(assert_equal("joint_2", robot.joint("joint_2")->name()));
 }
 
-TEST(Robot, isSimilar) {
-  // Initialize Robot instance from a file.
-  using simple_rr::robot;
-
-  //Initialize second robot
-  auto robot_2 = gtdynamics::CreateRobotFromFile(
-      kSdfPath + std::string("/test/simple_rr.sdf"), "simple_rr_sdf");
-  Robot robot_3 =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
-
-  //Check that the robots are identical
-  EXPECT(robot.isIdentical(robot_2));
-  EXPECT(!robot.isIdentical(robot_3));
-}
-
 TEST(Robot, removeLink) {
   // Initialize Robot instance from a file.
   using four_bar_linkage_pure::robot;

--- a/tests/testWalkCycle.cpp
+++ b/tests/testWalkCycle.cpp
@@ -37,27 +37,6 @@ TEST(WalkCycle, error) {
   EXPECT_LONGS_EQUAL(5, walk_cycle.contactPoints().size());
 }
 
-TEST(WalkCycle, robotModel) {
-
-  Robot robot =
-      CreateRobotFromFile(kSdfPath + std::string("/spider.sdf"), "spider");
-
-  // First phase
-  constexpr size_t num_time_steps = 2;
-  gtsam::Point3 contact_in_com(0, 0.19, 0);
-  Phase phase_1(robot, num_time_steps);
-  phase_1.addContactPoint("tarsus_1_L1", contact_in_com);
-  phase_1.addContactPoint("tarsus_2_L2", contact_in_com);
-
-  // Second phase
-  auto robot_2 = gtdynamics::CreateRobotFromFile(
-      kSdfPath + std::string("/test/simple_rr.sdf"), "simple_rr_sdf");
-  Phase phase_2(robot_2, num_time_steps);
-  phase_2.addContactPoint("link_0", contact_in_com);
-  phase_2.addContactPoint("link_1", contact_in_com);
-  THROWS_EXCEPTION(WalkCycle({phase_1, phase_2}));
-}
-
 TEST(WalkCycle, inverse_kinematics) {
   Robot robot =
       CreateRobotFromFile(kUrdfPath + std::string("/vision60.urdf"), "spider");
@@ -65,11 +44,11 @@ TEST(WalkCycle, inverse_kinematics) {
 
   constexpr size_t num_time_steps = 5;
   const Point3 contact_in_com(0.14, 0, 0);
-  Phase phase0(robot, num_time_steps), phase1(robot, num_time_steps);
-  phase0.addContactPoint("lower1", contact_in_com);  // LH
-  phase1.addContactPoint("lower0", contact_in_com);  // LF
-  phase0.addContactPoint("lower2", contact_in_com);  // RF
-  phase1.addContactPoint("lower3", contact_in_com);  // RH
+  Phase phase0(num_time_steps), phase1(num_time_steps);
+  phase0.addContactPoint(robot.link("lower1"), contact_in_com);  // LH
+  phase1.addContactPoint(robot.link("lower0"), contact_in_com);  // LF
+  phase0.addContactPoint(robot.link("lower2"), contact_in_com);  // RF
+  phase1.addContactPoint(robot.link("lower3"), contact_in_com);  // RH
   auto walk_cycle = WalkCycle({phase0, phase1});
 
   // Set goal points to reasonable values

--- a/tests/walkCycleExample.h
+++ b/tests/walkCycleExample.h
@@ -19,21 +19,23 @@ namespace gtdynamics {
 namespace walk_cycle_example {
 
 Robot robot =
-      CreateRobotFromFile(kSdfPath + std::string("/spider.sdf"), "spider");
+  CreateRobotFromFile(kSdfPath + std::string("/spider.sdf"), "spider");
 
 // First phase
 constexpr size_t num_time_steps = 2;
 const gtsam::Point3 contact_in_com(0, 0.19, 0);
-const Phase phase_1(robot, num_time_steps,
-                    {"tarsus_1_L1", "tarsus_2_L2", "tarsus_3_L3"},
-                    contact_in_com);
+const std::vector<LinkSharedPtr> links_1 = {robot.link("tarsus_1_L1"),
+                                            robot.link("tarsus_2_L2"),
+                                            robot.link("tarsus_3_L3")};
+const Phase phase_1(num_time_steps, links_1, contact_in_com);
 
 // Second phase
 constexpr size_t num_time_steps_2 = 3;
-const Phase phase_2(robot, num_time_steps_2,
-                    {"tarsus_2_L2", "tarsus_3_L3", "tarsus_4_L4",
-                     "tarsus_5_R4"},
-                    contact_in_com);
+const std::vector<LinkSharedPtr> links_2 = {robot.link("tarsus_2_L2"),
+                                            robot.link("tarsus_3_L3"),
+                                            robot.link("tarsus_4_L4"),
+                                            robot.link("tarsus_5_R4")};
+const Phase phase_2(num_time_steps_2, links_2, contact_in_com);
 
 // Initialize walk cycle
 const WalkCycle walk_cycle({phase_1, phase_2});


### PR DESCRIPTION
Changes that I have made:
- Removed `robot_` attributes from Trajectory and updated affected code accordingly
- Updated affected code from removing the `Robot.isIdentical()` method
- Updated affected code from using `LinkSharedPtr` as opposed of `vector<string>` of link names in `Phase.h`

Issues to note:
- In `testStaticsSlice.cpp` the `Torque` method is producing different results but @varunagrawal said it is a bug that he already reported.
- In `testPhase.cpp` the resulting print statement from phase does not match the formatting of the unit test. The unit tests' resulting print is `tarsus_1_L1: [   0 0.19    0], tarsus_2_L2: [   0 0.19    0], tarsus_3_L3: [   0 0.19    0], ]` while the current phase print is:
```
[tarsus_1_L1:    0
0.19
   0, tarsus_2_L2:    0
0.19
   0, tarsus_3_L3:    0
0.19
   0, ]
```