### PR TITLE
Cleanup & new ContactPointFactor

### DIFF
--- a/gtdynamics/factors/ContactEqualityFactor.h
+++ b/gtdynamics/factors/ContactEqualityFactor.h
@@ -7,7 +7,7 @@
 
 /**
  * @file  ContactEqualityFactor.h
- * @brief Factor to constrain contact points to be equal.
+ * @brief Factor to constrain temporal contact points to be equal.
  * @author Varun Agrawal
  */
 

--- a/gtdynamics/factors/ContactHeightFactor.h
+++ b/gtdynamics/factors/ContactHeightFactor.h
@@ -8,7 +8,7 @@
 /**
  * @file  ContactHeightFactor.h
  * @brief Factor to enforce zero height at the contact point.
- * @author: Alejandro Escontrela
+ * @author: Alejandro Escontrela, Varun Agrawal
  */
 
 #pragma once
@@ -18,12 +18,7 @@
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 
-#include <boost/optional.hpp>
-#include <iostream>
 #include <string>
-#include <vector>
-
-#include "gtdynamics/utils/utils.h"
 
 namespace gtdynamics {
 
@@ -44,7 +39,7 @@ class ContactHeightFactor : public gtsam::NoiseModelFactor1<gtsam::Pose3> {
 
  public:
   /**
-   * Contact kinematics factor for link end to remain in contact with the
+   * Factor for link end to remain in contact with the
    * ground.
    *
    * @param pose_key The key corresponding to the link's CoM pose.
@@ -66,7 +61,6 @@ class ContactHeightFactor : public gtsam::NoiseModelFactor1<gtsam::Pose3> {
 
   virtual ~ContactHeightFactor() {}
 
- public:
   /**
    * Evaluate contact errors.
    * @param sTl This link's COM pose in the spatial frame.

--- a/gtdynamics/factors/ContactPointFactor.h
+++ b/gtdynamics/factors/ContactPointFactor.h
@@ -1,0 +1,113 @@
+/* ----------------------------------------------------------------------------
+ * GTDynamics Copyright 2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file  ContactPointFactor.h
+ * @brief Factor to enforce point on link is in contact with environment point.
+ * @author: Varun Agrawal
+ */
+
+#pragma once
+
+#include <gtsam/base/Matrix.h>
+#include <gtsam/base/Vector.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
+
+#include <string>
+
+#include "gtdynamics/utils/ContactPoint.h"
+
+namespace gtdynamics {
+
+/**
+ * ContactPointFactor is a two-way nonlinear factor which enforces a
+ * point on the link to be equal to the point of contact in the environment.
+ */
+class ContactPointFactor
+    : public gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Point3> {
+ private:
+  using This = ContactPointFactor;
+  using Base = gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Point3>;
+
+  gtsam::Point3 lPc_;  // The contact point in the link's COM frame.
+
+ public:
+  /**
+   * Constructor.
+   *
+   * @param link_pose_key Key for the CoM pose of the link in contact.
+   * @param point_key Key for the contact point in the environment.
+   * @param cost_model Noise model associated with this factor.
+   * @param lPc Static transform from point of contact to link CoM.
+   */
+  ContactPointFactor(gtsam::Key link_pose_key, gtsam::Key point_key,
+                     const gtsam::noiseModel::Base::shared_ptr &cost_model,
+                     const gtsam::Point3 &lPc)
+      : Base(cost_model, link_pose_key, point_key), lPc_(lPc) {}
+
+  /**
+   * Convenience constructor which uses PointOnLink.
+   *
+   * @param point_on_link PointOnLink object which encapsulates the link and its
+   * contact point.
+   * @param point_key Key for the contact point in the environment.
+   * @param cost_model Noise model associated with this factor.
+   * @param t The time step at which to add the factor (default t=0).
+   */
+  ContactPointFactor(const PointOnLink &point_on_link, gtsam::Key point_key,
+                     const gtsam::noiseModel::Base::shared_ptr &cost_model,
+                     size_t t = 0)
+      : Base(cost_model,
+             gtdynamics::internal::PoseKey(point_on_link.link->id(), t),
+             point_key),
+        lPc_(point_on_link.point) {}
+
+  virtual ~ContactPointFactor() {}
+
+  /**
+   * Evaluate error.
+   * @param wTl The link's COM pose in the world frame.
+   * @param wPc The environment contact point in the world frame.
+   */
+  gtsam::Vector evaluateError(
+      const gtsam::Pose3 &wTl, const gtsam::Point3 &wPc,
+      boost::optional<gtsam::Matrix &> H_pose = boost::none,
+      boost::optional<gtsam::Matrix &> H_point = boost::none) const override {
+    gtsam::Vector error = gtsam::traits<gtsam::Point3>::Local(
+        wTl.transformFrom(lPc_, H_pose), wPc);
+    if (H_pose) *H_pose = -gtsam::Matrix3::Identity() * (*H_pose);
+    if (H_point) *H_point = gtsam::Matrix3::Identity();
+    return error;
+  }
+
+  //// @return a deep copy of this factor
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+        gtsam::NonlinearFactor::shared_ptr(new This(*this)));
+  }
+
+  /// print contents
+  void print(const std::string &s = "",
+             const gtsam::KeyFormatter &keyFormatter =
+                 gtsam::DefaultKeyFormatter) const override {
+    std::cout << (s.empty() ? "" : s + " ") << "ContactPointFactor"
+              << std::endl;
+    Base::print("", keyFormatter);
+  }
+
+ private:
+  /// Serialization function
+  friend class boost::serialization::access;
+  template <class ARCHIVE>
+  void serialize(ARCHIVE &ar, const unsigned int version) {  // NOLINT
+    ar &boost::serialization::make_nvp(
+        "NonlinearEquality2", boost::serialization::base_object<Base>(*this));
+  }
+};
+
+}  // namespace gtdynamics

--- a/gtdynamics/factors/ForwardKinematicsFactor.h
+++ b/gtdynamics/factors/ForwardKinematicsFactor.h
@@ -74,7 +74,7 @@ class ForwardKinematicsFactor : public gtsam::BetweenFactor<gtsam::Pose3> {
    * @param end_link_name   The end link name whose pose to compute via FK.
    * @param joint_angles    gtsam::Values with joint angles for relevant joints.
    * @param model           The noise model for this factor.
-   * @param k               The discretized time index.
+   * @param k               The discrete time index.
    */
   ForwardKinematicsFactor(const Robot &robot,
                           const std::string &start_link_name,

--- a/gtdynamics/factors/ForwardKinematicsFactor.h
+++ b/gtdynamics/factors/ForwardKinematicsFactor.h
@@ -53,7 +53,7 @@ class ForwardKinematicsFactor : public gtsam::BetweenFactor<gtsam::Pose3> {
    * @param end_link_name   The end link name whose pose to compute via FK.
    * @param joint_angles    gtsam::Values with joint angles for relevant joints.
    * @param model           The noise model for this factor.
-   * @param k               The discretized time index.
+   * @param k               The discrete time index.
    */
   ForwardKinematicsFactor(gtsam::Key bTl1_key, gtsam::Key bTl2_key,
                           const Robot &robot,

--- a/tests/testContactPointFactor.cpp
+++ b/tests/testContactPointFactor.cpp
@@ -1,0 +1,86 @@
+/* ----------------------------------------------------------------------------
+ * GTDynamics Copyright 2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file  testContactPointFactor.cpp
+ * @brief Test ContactPointFactor.
+ * @author Varun Agrawal
+ */
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Testable.h>
+#include <gtsam/base/TestableAssertions.h>
+#include <gtsam/base/numericalDerivative.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/GaussNewtonOptimizer.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/nonlinear/factorTesting.h>
+
+#include <iostream>
+
+#include "gtdynamics/factors/ContactPointFactor.h"
+#include "gtdynamics/universal_robot/RobotModels.h"
+#include "gtdynamics/utils/values.h"
+
+using namespace gtdynamics;
+using namespace gtsam;
+using gtsam::assert_equal;
+
+auto kModel = noiseModel::Isotropic::Sigma(3, 0.1);
+
+using simple_rr::robot;
+
+TEST(ContactPointFactor, Constructor) {
+  Key link_pose_key = gtdynamics::internal::PoseKey(0, 0),
+      point_key = gtdynamics::internal::PoseKey(1, 0);
+  Point3 lPc(0, 0, 1);
+  ContactPointFactor(link_pose_key, point_key, kModel, lPc);
+
+  PointOnLink point_on_link(robot.links()[0], lPc);
+  ContactPointFactor(point_on_link, point_key, kModel, 10);
+}
+
+TEST(ContactPointFactor, Error) {
+  LinkSharedPtr end_link = robot.links()[0];
+  PointOnLink point_on_link{end_link, Point3(0, 0, 1)};
+
+  Key point_key = gtdynamics::internal::PoseKey(1, 0);
+  Point3 wPc(0, 0, 1);
+
+  ContactPointFactor factor(point_on_link, point_key, kModel, 0);
+
+  Vector error = factor.evaluateError(point_on_link.link->wTl(), wPc);
+  EXPECT(assert_equal(Vector3::Zero(), error, 1e-9));
+
+  // Check error when contact point is not consistent
+  Point3 wPc2(1, 1, 2);
+  error = factor.evaluateError(point_on_link.link->wTl(), wPc2);
+  EXPECT(assert_equal(Vector3::Ones(), error, 1e-9));
+}
+
+TEST(ContactPointFactor, Jacobians) {
+  auto end_link = robot.links()[0];
+  PointOnLink point_on_link{end_link, Point3(0, 0, 1)};
+
+  Key point_key = gtdynamics::internal::PoseKey(1, 0);
+  Point3 wPc(0, 0, 1);
+
+  ContactPointFactor factor(point_on_link, point_key, kModel, 0);
+
+  Values values;
+  InsertPose(&values, end_link->id(), 0, point_on_link.link->wTl());
+  values.insert<Point3>(point_key, wPc);
+
+  // Check Jacobians
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
+}
+
+int main() {
+  TestResult tr;
+  return TestRegistry::runAllTests(tr);
+}


### PR DESCRIPTION
Added a new factor to allow for constraining between the link CoM and the point of contact.
Doing this rather than using a `NonlinearEqualityFactor` since the variable types are `Pose3` and `Point3`, and not a single type.