### PR TITLE
Compile everything by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,8 @@ find_package(sdformat${SDFormat_VERSION} REQUIRED)
 # ##############################################################################
 # Dynamics library
 # ##############################################################################
-option(GTDYNAMICS_BUILD_CABLE_ROBOT "Build Cable Robot" OFF)
-option(GTDYNAMICS_BUILD_JUMPING_ROBOT "Build Jumping Robot" OFF)
+option(GTDYNAMICS_BUILD_CABLE_ROBOT "Build Cable Robot" ON)
+option(GTDYNAMICS_BUILD_JUMPING_ROBOT "Build Jumping Robot" ON)
 
 add_subdirectory(gtdynamics)
 
@@ -66,12 +66,12 @@ endif()
 # Process subdirectories.
 add_subdirectory(tests)
 
-option(GTDYNAMICS_BUILD_SCRIPTS "Build all scripts" OFF)
+option(GTDYNAMICS_BUILD_SCRIPTS "Build all scripts" ON)
 if(GTDYNAMICS_BUILD_SCRIPTS)
   add_subdirectory(scripts)
 endif()
 
-option(GTDYNAMICS_BUILD_EXAMPLES "Build all examples" OFF)
+option(GTDYNAMICS_BUILD_EXAMPLES "Build all examples" ON)
 if(GTDYNAMICS_BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()


### PR DESCRIPTION
Turned on jumping robot and cable robot, as well as examples and scripts.

This makes sure that if we make changes (in this early dev phase) we catch compile issues in all that code early, as opposed to only seeing it in CI.

If you are just using a subset and note hacking core code, feel free to turn them OFF using (for example) ccmake.