### PR TITLE
Bring Back wTl as bMlink, Issue #260

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -179,12 +179,13 @@ class ContactHeightFactor : gtsam::NonlinearFactor {
 class Link  {
   Link();
   Link(int id, const string &name, const double mass,
-       const Matrix &inertia, const gtsam::Pose3 &bMcom, bool is_fixed = false) ;    
+       const Matrix &inertia, const gtsam::Pose3 &bMcom, const gtsam::Pose3 &bMlink, bool is_fixed = false) ;    
 
   gtdynamics::Link *shared();
   int id() const;
   void addJoint(gtdynamics::Joint *joint_ptr);
   const gtsam::Pose3 bMcom() const;
+  const gtsam::Pose3 bMlink() const;
   const gtsam::Pose3 &getFixedPose() const;
   bool isFixed() const;
   void fix();

--- a/gtdynamics/cablerobot/src/cdpr_planar.py
+++ b/gtdynamics/cablerobot/src/cdpr_planar.py
@@ -32,7 +32,7 @@ class Cdpr:
     """
     def __init__(self, params=CdprParams()):
         self.params = params
-        ee = gtd.Link(1, "ee", params.mass, params.inertia, Pose3())
+        ee = gtd.Link(1, "ee", params.mass, params.inertia, Pose3(), Pose3())
         self.robot = gtd.Robot({'ee': ee}, {})
         self.costmodel_l = gtsam.noiseModel.Isotropic.Sigma(1, 0.001)
         self.costmodel_ldot = gtsam.noiseModel.Isotropic.Sigma(1, 0.001)

--- a/gtdynamics/universal_robot/Link.h
+++ b/gtdynamics/universal_robot/Link.h
@@ -57,7 +57,8 @@ class Link : public boost::enable_shared_from_this<Link> {
   gtsam::Matrix3 inertia_;
 
   /// SDF Elements.
-  gtsam::Pose3 bMcom_;  // CoM frame defined in the base frame in rest.
+  gtsam::Pose3 bMcom_;  // CoM frame defined in the base frame at rest.
+  gtsam::Pose3 bMlink_; // link frame defined in the base frame at rest.
 
   /// Option to fix the link, used for ground link
   bool is_fixed_;
@@ -77,15 +78,17 @@ class Link : public boost::enable_shared_from_this<Link> {
    * @param mass The mass of the link.
    * @param inertia The inertial matrix of the link.
    * @param bMcom The pose of the link CoM relative to the base frame.
+   * @param bMlink The pose of the link frame relative to the base frame.
    * @param is_fixed Flag indicating if the link is fixed.
    */
   Link(uint8_t id, const std::string &name, const double mass,
-       const gtsam::Matrix3 &inertia, const gtsam::Pose3 &bMcom, bool is_fixed = false)
+       const gtsam::Matrix3 &inertia, const gtsam::Pose3 &bMcom, const gtsam::Pose3 &bMlink, bool is_fixed = false)
       : id_(id),
         name_(name),
         mass_(mass),
         inertia_(inertia),
         bMcom_(bMcom),
+        bMlink_(bMlink),
         is_fixed_(is_fixed) {}
 
   /** destructor */
@@ -97,6 +100,7 @@ class Link : public boost::enable_shared_from_this<Link> {
             this->centerOfMass_.equals(other.centerOfMass_) &&
             this->inertia_ == other.inertia_ &&
             this->bMcom_.equals(other.bMcom_) &&
+            this->bMlink_.equals(other.bMlink_) &&
             this->is_fixed_ == other.is_fixed_ &&
             this->fixed_pose_.equals(other.fixed_pose_));
   }
@@ -119,6 +123,9 @@ class Link : public boost::enable_shared_from_this<Link> {
 
   /// Relative pose at rest from link’s COM to the base frame.
   inline const gtsam::Pose3 bMcom() const { return bMcom_; }
+
+    /// Relative pose at rest from link frame to the base frame. mainly for interoperability uses
+  inline const gtsam::Pose3 bMlink() const { return bMlink_; }
 
   /// the fixed pose of the link
   const gtsam::Pose3 &getFixedPose() const { return fixed_pose_; }

--- a/gtdynamics/universal_robot/sdf.cpp
+++ b/gtdynamics/universal_robot/sdf.cpp
@@ -154,7 +154,7 @@ LinkSharedPtr LinkFromSdf(uint8_t id, const sdf::Link &sdf_link) {
 
   return boost::make_shared<Link>(id, sdf_link.Name(),
                                   sdf_link.Inertial().MassMatrix().Mass(),
-                                  inertia, bMcom);
+                                  inertia, bMcom, bMl);
 }
 
 LinkSharedPtr LinkFromSdf(uint8_t id, const std::string &link_name,

--- a/python/tests/test_four_bar.py
+++ b/python/tests/test_four_bar.py
@@ -33,10 +33,10 @@ class TestFourBar(unittest.TestCase):
         l4_pose = Pose3(Rot3.Rz(np.pi * 3 / 2), (0, 2, 0))
         com = Pose3(Rot3(), (1, 0, 0))
 
-        link1 = gtd.Link(1, "l1", 1, inertia, l1_pose*com)
-        link2 = gtd.Link(2, "l2", 1, inertia, l2_pose*com)
-        link3 = gtd.Link(3, "l3", 1, inertia, l3_pose*com)
-        link4 = gtd.Link(4, "l4", 1, inertia, l4_pose*com, True)
+        link1 = gtd.Link(1, "l1", 1, inertia, l1_pose*com, l1_pose)
+        link2 = gtd.Link(2, "l2", 1, inertia, l2_pose*com, l2_pose)
+        link3 = gtd.Link(3, "l3", 1, inertia, l3_pose*com, l3_pose)
+        link4 = gtd.Link(4, "l4", 1, inertia, l4_pose*com, l4_pose, True)
 
         links = {"l1": link1, "l2": link2, "l3": link3, "l4": link4}
 

--- a/tests/make_joint.h
+++ b/tests/make_joint.h
@@ -25,10 +25,11 @@ boost::shared_ptr<const ScrewJointBase> make_joint(gtsam::Pose3 cMp,
   double mass = 100;
   gtsam::Matrix3 inertia = gtsam::Vector3(3, 2, 1).asDiagonal();
   gtsam::Pose3 bMcom;
+  gtsam::Pose3 bMl;
 
-  auto l1 = boost::make_shared<Link>(Link(1, name, mass, inertia, bMcom));
+  auto l1 = boost::make_shared<Link>(Link(1, name, mass, inertia, bMcom, bMl));
   auto l2 = boost::make_shared<Link>(
-      Link(2, name, mass, inertia, cMp.inverse()));
+      Link(2, name, mass, inertia, cMp.inverse(), bMl));
 
   // create joint
   JointParams joint_params;

--- a/tests/testLink.cpp
+++ b/tests/testLink.cpp
@@ -30,7 +30,7 @@ using gtsam::Rot3;
 // Construct the same link via Params and ensure all values are as expected.
 TEST(Link, params_constructor) {
   Link l1(1, "l1", 100.0, gtsam::Vector3(3, 2, 1).asDiagonal(),
-          Pose3(Rot3(), Point3(0, 0, 1)));
+          Pose3(Rot3(), Point3(0, 0, 1)), Pose3());
 
   // name
   EXPECT(assert_equal("l1", l1.name()));

--- a/tests/testSdf.cpp
+++ b/tests/testSdf.cpp
@@ -386,6 +386,13 @@ TEST(Sdf, limit_params) {
   LinkSharedPtr l1 = LinkFromSdf(1, *model.LinkByName("l1"));
   LinkSharedPtr l2 = LinkFromSdf(2, *model.LinkByName("l2"));
 
+  //check link and com frames
+  EXPECT(assert_equal(Pose3(), l1->bMlink()));
+  EXPECT(assert_equal(Pose3(Rot3(), Point3(0, 0, 1)), l1->bMcom()));
+  Rot3 R_check = Rot3::Rx(1.5708);
+  EXPECT(assert_equal(Pose3(R_check, Point3(0, 0, 2)), l2->bMlink(), 1e-3));
+  EXPECT(assert_equal(Pose3(R_check, Point3(0, -1, 2)), l2->bMcom(), 1e-3));
+  
   auto sdf_link_l1 = model.LinkByName("l1");
   auto sdf_link_l2 = model.LinkByName("l2");
 
@@ -598,6 +605,13 @@ TEST(Robot, simple_urdf) {
                       j1->relativePoseOf(j1->parent(), 0)));
   EXPECT(assert_equal(gtsam::Pose3(gtsam::Rot3(), gtsam::Point3(0, 0, 2)),
                       j1->relativePoseOf(j1->child(), 0)));
+
+  // Check link frames and com frames are correct
+  EXPECT(assert_equal(Pose3(Rot3(), Point3(0, 0, 1)), l1->bMcom()));
+  EXPECT(assert_equal(Pose3(Rot3(), Point3(0, 0, 3)), l2->bMcom()));
+  EXPECT(assert_equal(Pose3(Rot3(), Point3(0, 0, 0)), l1->bMlink()));
+  EXPECT(assert_equal(Pose3(Rot3(), Point3(0, 0, 2)), l2->bMlink()));
+
 }
 
 // Check the links in the simple RR robot.
@@ -610,6 +624,10 @@ TEST(Sdf, sdf_constructor) {
   // Verify center of mass defined in the world frame is correct.
   EXPECT(assert_equal(Pose3(Rot3(), Point3(0, 0, 0.1)), l0.bMcom()));
   EXPECT(assert_equal(Pose3(Rot3(), Point3(0, 0, 0.5)), l1.bMcom()));
+
+  // Verify link frame of both links is identity.
+  EXPECT(assert_equal(Pose3(), l0.bMlink()));
+  EXPECT(assert_equal(Pose3(), l1.bMlink()));
 
   // Verify that mass is correct.
   EXPECT(assert_equal(0.01, l0.mass()));

--- a/tests/testStaticsSlice.cpp
+++ b/tests/testStaticsSlice.cpp
@@ -44,8 +44,8 @@ TEST(Statics, OneMovingLink) {
   const Pose3 bMcom(Rot3(), Point3(L / 2, 0, 0));
   const auto I3 = Matrix3::Identity();  // inertia
   auto base =
-      boost::make_shared<Link>(0, "base", 1e10, I3, Pose3(), true);
-  auto link = boost::make_shared<Link>(1, "link", 1.0, I3, bMcom);
+      boost::make_shared<Link>(0, "base", 1e10, I3, Pose3(), Pose3(), true);
+  auto link = boost::make_shared<Link>(1, "link", 1.0, I3, bMcom, Pose3());
 
   // Create joint
   constexpr unsigned char id = 22;


### PR DESCRIPTION
Link class has bMlink_ member now and corresponding method.
Constructor adjusted.
tests adjusted ( and added a little).
python wrapper adjusted.
