### PR TITLE
Remove need for leading slash when loading robot models

### DIFF
--- a/examples/example_cart_pole_trajectory_optimization/main.cpp
+++ b/examples/example_cart_pole_trajectory_optimization/main.cpp
@@ -33,7 +33,7 @@ using gtsam::noiseModel::Isotropic, gtsam::noiseModel::Constrained;
 
 int main(int argc, char** argv) {
   // Load the inverted pendulum.
-  auto cp = CreateRobotFromFile(kUrdfPath + std::string("/cart_pole.urdf"));
+  auto cp = CreateRobotFromFile(kUrdfPath + std::string("cart_pole.urdf"));
   int j0_id = cp.joint("j0")->id(), j1_id = cp.joint("j1")->id();
   cp = cp.fixLink("l0");
   cp.print();

--- a/examples/example_forward_dynamics/main.cpp
+++ b/examples/example_forward_dynamics/main.cpp
@@ -9,7 +9,7 @@ using namespace gtdynamics;
 int main(int argc, char** argv) {
   // Load the robot
   auto simple_rr = CreateRobotFromFile(
-      kSdfPath + std::string("/test/simple_rr.sdf"), "simple_rr_sdf");
+      kSdfPath + std::string("test/simple_rr.sdf"), "simple_rr_sdf");
   simple_rr.print();
 
   gtsam::Vector3 gravity(0, 0, -9.8);

--- a/examples/example_full_kinodynamic_balancing/main.cpp
+++ b/examples/example_full_kinodynamic_balancing/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
   // Load the Vision 60 quadruped by Ghost robotics:
   // https://youtu.be/wrBNJKZKg10
   auto vision60 =
-      CreateRobotFromFile(kUrdfPath + std::string("/vision60.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("vision60.urdf"));
 
   // Env parameters.
   gtsam::Vector3 gravity = (gtsam::Vector(3) << 0, 0, -9.8).finished();

--- a/examples/example_full_kinodynamic_walking/main_rotate.cpp
+++ b/examples/example_full_kinodynamic_walking/main_rotate.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
   // Load the quadruped. Based on the vision 60 quadruped by Ghost robotics:
   // https://youtu.be/wrBNJKZKg10
   auto robot =
-      gtdynamics::CreateRobotFromFile(kUrdfPath + string("/vision60.urdf"));
+      gtdynamics::CreateRobotFromFile(kUrdfPath + string("vision60.urdf"));
 
   double sigma_dynamics = 1e-6;    // std of dynamics constraints.
   double sigma_objectives = 1e-4;  // std of additional objectives.

--- a/examples/example_full_kinodynamic_walking/main_walk_forward.cpp
+++ b/examples/example_full_kinodynamic_walking/main_walk_forward.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv) {
   // Load the quadruped. Based on the vision 60 quadruped by Ghost robotics:
   // https://youtu.be/wrBNJKZKg10
   auto robot =
-      gtdynamics::CreateRobotFromFile(kUrdfPath + string("/vision60.urdf"));
+      gtdynamics::CreateRobotFromFile(kUrdfPath + string("vision60.urdf"));
 
   double sigma_dynamics = 1e-6;    // std of dynamics constraints.
   double sigma_objectives = 1e-4;  // std of additional objectives.

--- a/examples/example_inverted_pendulum_trajectory_optimization/main.cpp
+++ b/examples/example_inverted_pendulum_trajectory_optimization/main.cpp
@@ -34,7 +34,7 @@ using gtsam::noiseModel::Isotropic;
 int main(int argc, char** argv) {
   // Load the inverted pendulum.
   auto ip =
-      CreateRobotFromFile(kUrdfPath + std::string("/inverted_pendulum.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("inverted_pendulum.urdf"));
   auto j1_id = ip.joint("j1")->id();
   ip = ip.fixLink("l1");
   ip.print();

--- a/examples/example_quadruped_mp/main.cpp
+++ b/examples/example_quadruped_mp/main.cpp
@@ -257,7 +257,7 @@ struct CsvWriter {
 int main(int argc, char **argv) {
   // Load the vision 60 quadruped by Ghost robotics:
   // https://youtu.be/wrBNJKZKg10
-  Robot robot = CreateRobotFromFile(kUrdfPath + std::string("/vision60.urdf"));
+  Robot robot = CreateRobotFromFile(kUrdfPath + std::string("vision60.urdf"));
 
   // Coordinate system:
   //  z

--- a/examples/example_spider_walking/main.cpp
+++ b/examples/example_spider_walking/main.cpp
@@ -65,7 +65,7 @@ Trajectory getTrajectory(const Robot& robot, size_t repeat) {
 int main(int argc, char** argv) {
   // Load Stephanie's spider robot.
   auto robot =
-      CreateRobotFromFile(kSdfPath + string("/spider_alt.sdf"), "spider");
+      CreateRobotFromFile(kSdfPath + string("spider_alt.sdf"), "spider");
 
   double sigma_dynamics = 1e-5;    // std of dynamics constraints.
   double sigma_objectives = 1e-6;  // std of additional objectives.

--- a/examples/example_spider_walking/main_rotate.cpp
+++ b/examples/example_spider_walking/main_rotate.cpp
@@ -53,7 +53,7 @@ using namespace gtdynamics;
 
 int main(int argc, char** argv) {
   // Load Stephanie's spider robot.
-  auto robot = gtdynamics::CreateRobotFromFile(kSdfPath + string("/spider.sdf"),
+  auto robot = gtdynamics::CreateRobotFromFile(kSdfPath + string("spider.sdf"),
                                                "spider");
 
   double sigma_dynamics = 1e-5;    // std of dynamics constraints.

--- a/gtdynamics/config.h.in
+++ b/gtdynamics/config.h.in
@@ -27,7 +27,7 @@
 
 namespace gtdynamics {
 // Paths to SDF & URDF files.
-constexpr const char* kSdfPath = "@PROJECT_SOURCE_DIR@/sdfs";
-constexpr const char* kUrdfPath = "@PROJECT_SOURCE_DIR@/urdfs";
-constexpr const char* kTestPath = "@PROJECT_SOURCE_DIR@/tests";
+constexpr const char* kSdfPath = "@PROJECT_SOURCE_DIR@/sdfs/";
+constexpr const char* kUrdfPath = "@PROJECT_SOURCE_DIR@/urdfs/";
+constexpr const char* kTestPath = "@PROJECT_SOURCE_DIR@/tests/";
 }  // namespace gtdynamics

--- a/gtdynamics/universal_robot/RobotModels.h
+++ b/gtdynamics/universal_robot/RobotModels.h
@@ -19,86 +19,83 @@
 #include "gtdynamics/universal_robot/Robot.h"
 #include "gtdynamics/universal_robot/sdf.h"
 
-// TODO(aescontrela): The entire program shouldn't crash when a single file
-// doesn't load.
-
 using gtdynamics::kSdfPath;
 using gtdynamics::kUrdfPath;
 
 namespace four_bar_linkage_pure {
 gtdynamics::Robot getRobot() {
   gtdynamics::Robot four_bar = gtdynamics::CreateRobotFromFile(
-      kSdfPath + std::string("/test/four_bar_linkage_pure.sdf"));
+      kSdfPath + std::string("test/four_bar_linkage_pure.sdf"));
   return four_bar;
 }
 gtsam::Vector3 gravity = (gtsam::Vector(3) << 0, 0, 0).finished();
 gtsam::Vector3 planar_axis = (gtsam::Vector(3) << 1, 0, 0).finished();
 
-} // namespace four_bar_linkage_pure
+}  // namespace four_bar_linkage_pure
 
 namespace simple_urdf {
 gtdynamics::Robot getRobot() {
   auto robot = gtdynamics::CreateRobotFromFile(
-      kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      kUrdfPath + std::string("test/simple_urdf.urdf"));
   robot = robot.fixLink("l1");
   return robot;
 }
 gtsam::Vector3 gravity = (gtsam::Vector(3) << 0, 0, 0).finished();
 gtsam::Vector3 planar_axis = (gtsam::Vector(3) << 1, 0, 0).finished();
 
-} // namespace simple_urdf
+}  // namespace simple_urdf
 
 namespace simple_urdf_prismatic {
 gtdynamics::Robot getRobot() {
   auto robot = gtdynamics::CreateRobotFromFile(
-      kUrdfPath + std::string("/test/simple_urdf_prismatic.urdf"));
+      kUrdfPath + std::string("test/simple_urdf_prismatic.urdf"));
   robot = robot.fixLink("l1");
   return robot;
 }
-} // namespace simple_urdf_prismatic
+}  // namespace simple_urdf_prismatic
 
 namespace simple_urdf_zero_inertia {
 gtdynamics::Robot getRobot() {
   auto robot = gtdynamics::CreateRobotFromFile(
-      kUrdfPath + std::string("/test/simple_urdf_zero_inertia.urdf"));
+      kUrdfPath + std::string("test/simple_urdf_zero_inertia.urdf"));
   robot = robot.fixLink("l1");
   return robot;
 }
 gtsam::Vector3 gravity = (gtsam::Vector(3) << 0, 0, 0).finished();
 gtsam::Vector3 planar_axis = (gtsam::Vector(3) << 1, 0, 0).finished();
 
-} // namespace simple_urdf_zero_inertia
+}  // namespace simple_urdf_zero_inertia
 
 namespace simple_urdf_eq_mass {
 gtdynamics::Robot getRobot() {
   auto robot = gtdynamics::CreateRobotFromFile(
-      kUrdfPath + std::string("/test/simple_urdf_eq_mass.urdf"));
+      kUrdfPath + std::string("test/simple_urdf_eq_mass.urdf"));
   return robot;
 }
 gtsam::Vector3 gravity = (gtsam::Vector(3) << 0, 0, 0).finished();
 gtsam::Vector3 planar_axis = (gtsam::Vector(3) << 1, 0, 0).finished();
 
-} // namespace simple_urdf_eq_mass
+}  // namespace simple_urdf_eq_mass
 
 namespace simple_rr {
 gtdynamics::Robot getRobot() {
   auto robot = gtdynamics::CreateRobotFromFile(
-      kSdfPath + std::string("/test/simple_rr.sdf"), "simple_rr_sdf");
+      kSdfPath + std::string("test/simple_rr.sdf"), "simple_rr_sdf");
   return robot;
 }
 gtsam::Vector3 gravity = (gtsam::Vector(3) << 0, 0, 0).finished();
 gtsam::Vector3 planar_axis = (gtsam::Vector(3) << 1, 0, 0).finished();
 
-} // namespace simple_rr
+}  // namespace simple_rr
 
 namespace jumping_robot {
 gtdynamics::Robot getRobot() {
   gtdynamics::Robot jumping_robot = gtdynamics::CreateRobotFromFile(
-      kSdfPath + std::string("/test/jumping_robot.sdf"));
+      kSdfPath + std::string("test/jumping_robot.sdf"));
   jumping_robot = jumping_robot.fixLink("l0");
   return jumping_robot;
 }
 gtsam::Vector3 gravity = (gtsam::Vector(3) << 0, 0, -9.8).finished();
 gtsam::Vector3 planar_axis = (gtsam::Vector(3) << 1, 0, 0).finished();
 
-} // namespace jumping_robot
+}  // namespace jumping_robot

--- a/scripts/gerry00_ForwardDynamicsPrismatic.cpp
+++ b/scripts/gerry00_ForwardDynamicsPrismatic.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
   // Load the robot and build a nonlinear factor graph of kinodynamics
   // constraints.
   auto simple_rpr = CreateRobotFromFile(
-      kSdfPath + std::string("/test/simple_rpr.sdf"), "simple_rpr_sdf");
+      kSdfPath + std::string("test/simple_rpr.sdf"), "simple_rpr_sdf");
   std::cout << "\033[1;31m"
             << "Robot Model:"
             << "\033[0m\n"

--- a/scripts/stephanie02_spider_sdf.cpp
+++ b/scripts/stephanie02_spider_sdf.cpp
@@ -20,7 +20,7 @@ using namespace gtdynamics;
 
 int main(int argc, char** argv) {
   const Robot spider =
-      CreateRobotFromFile(kSdfPath + std::string("/spider.sdf"), "spider");
+      CreateRobotFromFile(kSdfPath + std::string("spider.sdf"), "spider");
 
   spider.print();
 

--- a/tests/contactGoalsExample.h
+++ b/tests/contactGoalsExample.h
@@ -19,7 +19,7 @@
 namespace gtdynamics {
 namespace contact_goals_example {
 const Robot robot =
-    CreateRobotFromFile(kUrdfPath + std::string("/vision60.urdf"));
+    CreateRobotFromFile(kUrdfPath + std::string("vision60.urdf"));
 
 const gtsam::Point3 contact_in_com(0.14, 0, 0);
 const LinkSharedPtr LH = robot.link("lower1"), LF = robot.link("lower0"),

--- a/tests/testContactEqualityFactor.cpp
+++ b/tests/testContactEqualityFactor.cpp
@@ -76,7 +76,7 @@ TEST(ContactEqualityFactor, Jacobians) {
 
 TEST(ContactEqualityFactor, ArbitraryTime) {
   Robot robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("test/simple_urdf.urdf"));
   auto end_link = robot.link("l2");
 
   size_t k1 = 81, k2 = k1+3;

--- a/tests/testDynamics.cpp
+++ b/tests/testDynamics.cpp
@@ -26,7 +26,7 @@ using namespace gtsam;
 namespace example {
 constexpr double g = 9.8;
 const Robot robot = gtdynamics::CreateRobotFromFile(
-    kSdfPath + std::string("/test/four_bar_linkage.sdf"));
+    kSdfPath + std::string("test/four_bar_linkage.sdf"));
 Vector3 gravity(0, 0, -g);
 }  // namespace example
 

--- a/tests/testDynamicsGraph.cpp
+++ b/tests/testDynamicsGraph.cpp
@@ -479,7 +479,7 @@ TEST(dynamicsFactorGraph_Contacts, dynamics_graph_simple_rr) {
 // Test contacts in dynamics graph.
 TEST(dynamicsFactorGraph_Contacts, dynamics_graph_biped) {
   // Load the robot from urdf file
-  Robot biped = CreateRobotFromFile(kUrdfPath + std::string("/biped.urdf"));
+  Robot biped = CreateRobotFromFile(kUrdfPath + std::string("biped.urdf"));
 
   // Add some contact points.
   PointOnLinks contact_points;
@@ -557,7 +557,7 @@ TEST(jointlimitFactors, simple_urdf) {
 TEST(dynamicsFactorGraph_Contacts, dynamics_graph_simple_rrr) {
   // Load the robot from urdf file
   Robot robot = CreateRobotFromFile(
-      kSdfPath + std::string("/test/simple_rrr.sdf"), "simple_rrr_sdf");
+      kSdfPath + std::string("test/simple_rrr.sdf"), "simple_rrr_sdf");
 
   // Add some contact points.
   PointOnLinks contact_points;

--- a/tests/testForwardKinematicsFactor.cpp
+++ b/tests/testForwardKinematicsFactor.cpp
@@ -122,7 +122,7 @@ TEST(ForwardKinematicsFactor, Movement) {
 
 TEST(ForwardKinematicsFactor, ArbitraryTime) {
   Robot robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("test/simple_urdf.urdf"));
   std::string base_link = "l1", end_link = "l2";
 
   size_t t = 81;

--- a/tests/testInitializeSolutionUtils.cpp
+++ b/tests/testInitializeSolutionUtils.cpp
@@ -107,7 +107,7 @@ TEST(InitializeSolutionUtils, InitializeSolutionInterpolationMultiPhase) {
 
 TEST(InitializeSolutionUtils, InitializePosesAndJoints) {
   auto robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("test/simple_urdf.urdf"));
   auto l1 = robot.link("l1");
   auto l2 = robot.link("l2");
 
@@ -134,7 +134,7 @@ TEST(InitializeSolutionUtils, InitializePosesAndJoints) {
 
 TEST(InitializeSolutionUtils, InverseKinematics) {
   auto robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("test/simple_urdf.urdf"));
 
   auto l1 = robot.link("l1");
   auto l2 = robot.link("l2");
@@ -203,7 +203,7 @@ TEST(InitializeSolutionUtils, InverseKinematics) {
 
 TEST(InitializeSolutionUtils, ZeroValues) {
   auto robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("test/simple_urdf.urdf"));
 
   auto l1 = robot.link("l1");
   auto l2 = robot.link("l2");
@@ -230,7 +230,7 @@ TEST(InitializeSolutionUtils, ZeroValues) {
 
 TEST(InitializeSolutionUtils, ZeroValuesTrajectory) {
   auto robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("test/simple_urdf.urdf"));
 
   auto l1 = robot.link("l1");
   auto l2 = robot.link("l2");
@@ -257,7 +257,7 @@ TEST(InitializeSolutionUtils, ZeroValuesTrajectory) {
 
 TEST(InitializeSolutionUtils, MultiPhaseInverseKinematicsTrajectory) {
   auto robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("test/simple_urdf.urdf"));
 
   auto l1 = robot.link("l1");
   auto l2 = robot.link("l2");

--- a/tests/testObjectiveFactors.cpp
+++ b/tests/testObjectiveFactors.cpp
@@ -79,7 +79,7 @@ TEST(ObjectiveFactors, OptionalNoiseModels) {
 
 TEST(Phase, AddGoals) {
   Robot robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/vision60.urdf"), "spider");
+      CreateRobotFromFile(kUrdfPath + std::string("vision60.urdf"), "spider");
 
   // Foot is sphere of radius 1.1 cm, 14cm along X in COM
   Point3 point_com(0.14 + 0.011, 0, 0);

--- a/tests/testPhase.cpp
+++ b/tests/testPhase.cpp
@@ -27,7 +27,7 @@ using gtsam::Point3;
 
 TEST(Phase, All) {
   Robot robot =
-      CreateRobotFromFile(kSdfPath + std::string("/spider.sdf"), "spider");
+      CreateRobotFromFile(kSdfPath + std::string("spider.sdf"), "spider");
 
   using namespace walk_cycle_example;
   Point3 cp = phase_1.contactPoint("tarsus_3_L3");

--- a/tests/testRobot.cpp
+++ b/tests/testRobot.cpp
@@ -34,7 +34,7 @@ using gtsam::Vector6;
 TEST(Robot, four_bar_sdf) {
   // Initialize Robot instance from a file.
   Robot robot =
-      CreateRobotFromFile(kSdfPath + std::string("/test/four_bar_linkage.sdf"));
+      CreateRobotFromFile(kSdfPath + std::string("test/four_bar_linkage.sdf"));
 
   // Check that number of links and joints in the Robot instance is
   // correct.
@@ -85,7 +85,7 @@ TEST(Robot, removeLink) {
 
 TEST(Robot, ForwardKinematics) {
   Robot robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("test/simple_urdf.urdf"));
 
   Values values;
 
@@ -150,7 +150,7 @@ TEST(Robot, ForwardKinematics) {
 
 TEST(Robot, ForwardKinematicsRPR) {
   Robot robot = CreateRobotFromFile(
-      kSdfPath + std::string("/test/simple_rpr.sdf"), "simple_rpr_sdf");
+      kSdfPath + std::string("test/simple_rpr.sdf"), "simple_rpr_sdf");
 
   Values values;
 
@@ -207,7 +207,7 @@ TEST(Robot, ForwardKinematicsRPR) {
 // test fk for a four bar linkage (loopy)
 TEST(ForwardKinematics, FourBar) {
   Robot robot = CreateRobotFromFile(
-      kSdfPath + std::string("/test/four_bar_linkage_pure.sdf"));
+      kSdfPath + std::string("test/four_bar_linkage_pure.sdf"));
   robot = robot.fixLink("l1");
 
   Values values;

--- a/tests/testSdf.cpp
+++ b/tests/testSdf.cpp
@@ -35,7 +35,7 @@ using gtsam::Values;
 // Load a URDF file and ensure its joints and links were parsed correctly.
 TEST(Sdf, load_and_parse_urdf_file) {
   // Load the file and parse URDF structure.
-  auto simple_urdf = GetSdf(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+  auto simple_urdf = GetSdf(kUrdfPath + std::string("test/simple_urdf.urdf"));
 
   // Check that physical and inertial properties were properly parsed..
   EXPECT(assert_equal(2, simple_urdf.LinkCount()));
@@ -56,7 +56,7 @@ TEST(Sdf, load_and_parse_urdf_file) {
 }
 
 TEST(Sdf, load_and_parse_sdf_file) {
-  auto simple_sdf = GetSdf(kSdfPath + std::string("/test/simple.sdf"));
+  auto simple_sdf = GetSdf(kSdfPath + std::string("test/simple.sdf"));
 
   EXPECT(assert_equal(1, simple_sdf.LinkCount()));
   EXPECT(assert_equal(0, simple_sdf.JointCount()));
@@ -64,7 +64,7 @@ TEST(Sdf, load_and_parse_sdf_file) {
 
 TEST(Sdf, load_and_parse_sdf_world_file) {
   auto simple_sdf =
-      GetSdf(kSdfPath + std::string("/test/simple_rr.sdf"), "simple_rr_sdf");
+      GetSdf(kSdfPath + std::string("test/simple_rr.sdf"), "simple_rr_sdf");
 
   EXPECT(assert_equal(3, simple_sdf.LinkCount()));
   EXPECT(assert_equal(2, simple_sdf.JointCount()));
@@ -96,7 +96,7 @@ TEST(Sdf, Pose3FromIgnition) {
  */
 TEST(Sdf, parameters_from_file) {
   // Test for reading parameters from a simple URDF.
-  auto simple_urdf = GetSdf(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+  auto simple_urdf = GetSdf(kUrdfPath + std::string("test/simple_urdf.urdf"));
   auto j1_parameters = ParametersFromSdfJoint(*simple_urdf.JointByName("j1"));
 
   EXPECT(assert_equal(-1.57, j1_parameters.scalar_limits.value_lower_limit));
@@ -108,7 +108,7 @@ TEST(Sdf, parameters_from_file) {
   // Test for reading parameters (damping coefficient, velocity limit, and
   // torque limit) from a simple SDF.
   auto simple_sdf =
-      GetSdf(kSdfPath + std::string("/test/simple_rr.sdf"), "simple_rr_sdf");
+      GetSdf(kSdfPath + std::string("test/simple_rr.sdf"), "simple_rr_sdf");
   auto joint_1_parameters =
       ParametersFromSdfJoint(*simple_sdf.JointByName("joint_1"));
 
@@ -117,7 +117,7 @@ TEST(Sdf, parameters_from_file) {
   EXPECT(assert_equal(300, joint_1_parameters.torque_limit));
 
   // Test for reading parameters (joint limits) from spider.sdf.
-  auto spider_sdf = GetSdf(kSdfPath + std::string("/spider.sdf"), "spider");
+  auto spider_sdf = GetSdf(kSdfPath + std::string("spider.sdf"), "spider");
   auto knee_1_parameters =
       ParametersFromSdfJoint(*spider_sdf.JointByName("knee_1"));
 
@@ -134,7 +134,7 @@ TEST(Sdf, parameters_from_file) {
 TEST(Sdf, create_robot_from_file) {
   // Test for reading parameters from a robot created via simple URDF.
   auto simple_robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("test/simple_urdf.urdf"));
   auto simple_j1 = simple_robot.joint("j1");
 
   EXPECT(assert_equal(-1.57,
@@ -148,7 +148,7 @@ TEST(Sdf, create_robot_from_file) {
   // Test for reading parameters (damping coefficient, velocity limit, and
   // torque limit) from a robot created via simple SDF.
   auto simple_rr_robot = CreateRobotFromFile(
-      kSdfPath + std::string("/test/simple_rr.sdf"), "simple_rr_sdf");
+      kSdfPath + std::string("test/simple_rr.sdf"), "simple_rr_sdf");
   auto simple_rr_j1 = simple_rr_robot.joint("joint_1");
 
   EXPECT(assert_equal(0.5, simple_rr_j1->parameters().damping_coefficient));
@@ -158,7 +158,7 @@ TEST(Sdf, create_robot_from_file) {
   // Test for reading parameters (joint limits) from a robot created via
   // spider.sdf.
   auto spider_robot =
-      CreateRobotFromFile(kSdfPath + std::string("/spider.sdf"), "spider");
+      CreateRobotFromFile(kSdfPath + std::string("spider.sdf"), "spider");
   auto spider_knee1 = spider_robot.joint("knee_1");
 
   EXPECT(assert_equal(
@@ -171,7 +171,7 @@ TEST(Sdf, create_robot_from_file) {
  * Construct a Link via URDF and ensure all values are as expected.
  */
 TEST(Sdf, urdf_constructor_link) {
-  auto simple_urdf = GetSdf(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+  auto simple_urdf = GetSdf(kUrdfPath + std::string("test/simple_urdf.urdf"));
 
   // Initialize Robot instance using urdf::ModelInterfacePtr.
   LinkSharedPtr l1 = LinkFromSdf(1, *simple_urdf.LinkByName("l1"));
@@ -236,7 +236,7 @@ TEST(Sdf, urdf_constructor_link) {
  * Construct a Revolute Joint from URDF and ensure all values are as expected.
  */
 TEST(Sdf, urdf_constructor_revolute) {
-  auto simple_urdf = GetSdf(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+  auto simple_urdf = GetSdf(kUrdfPath + std::string("test/simple_urdf.urdf"));
 
   LinkSharedPtr l1 = LinkFromSdf(1, *simple_urdf.LinkByName("l1"));
   LinkSharedPtr l2 = LinkFromSdf(2, *simple_urdf.LinkByName("l2"));
@@ -310,12 +310,10 @@ TEST(Sdf, urdf_constructor_revolute) {
       assert_equal(1e-9, j1->parameters().scalar_limits.value_limit_threshold));
 }
 
-/**
- * Construct a Revolute Joint from SDF and ensure all values are as expected.
- */
+// Construct a Revolute Joint from SDF and ensure all values are as expected.
 TEST(Sdf, sdf_constructor_revolute) {
   auto model =
-      GetSdf(kSdfPath + std::string("/test/simple_rr.sdf"), "simple_rr_sdf");
+      GetSdf(kSdfPath + std::string("test/simple_rr.sdf"), "simple_rr_sdf");
 
   LinkSharedPtr l0 = LinkFromSdf(0, *model.LinkByName("link_0"));
   LinkSharedPtr l1 = LinkFromSdf(1, *model.LinkByName("link_1"));
@@ -382,7 +380,7 @@ TEST(Sdf, sdf_constructor_revolute) {
 // Test parsing of Revolute joint limit values from various robots.
 TEST(Sdf, limit_params) {
   // Check revolute joint limits parsed correctly for first test robot.
-  auto model = GetSdf(kSdfPath + std::string("/test/four_bar_linkage.sdf"));
+  auto model = GetSdf(kSdfPath + std::string("test/four_bar_linkage.sdf"));
   LinkSharedPtr l1 = LinkFromSdf(1, *model.LinkByName("l1"));
   LinkSharedPtr l2 = LinkFromSdf(2, *model.LinkByName("l2"));
 
@@ -412,7 +410,7 @@ TEST(Sdf, limit_params) {
 
   // Check revolute joint limits parsed correctly for a robot with no limits.
   auto model2 =
-      GetSdf(kSdfPath + std::string("/test/simple_rr.sdf"), "simple_rr_sdf");
+      GetSdf(kSdfPath + std::string("test/simple_rr.sdf"), "simple_rr_sdf");
 
   LinkSharedPtr link_0 = LinkFromSdf(0, *model2.LinkByName("link_0"));
   LinkSharedPtr link_1 = LinkFromSdf(1, *model2.LinkByName("link_1"));
@@ -447,7 +445,7 @@ TEST(Sdf, limit_params) {
  */
 TEST(Sdf, urdf_constructor_prismatic) {
   auto simple_urdf =
-      GetSdf(kUrdfPath + std::string("/test/simple_urdf_prismatic.urdf"));
+      GetSdf(kUrdfPath + std::string("test/simple_urdf_prismatic.urdf"));
 
   LinkSharedPtr l1 = LinkFromSdf(1, *simple_urdf.LinkByName("l1"));
   LinkSharedPtr l2 = LinkFromSdf(2, *simple_urdf.LinkByName("l2"));
@@ -524,7 +522,7 @@ TEST(Sdf, urdf_constructor_prismatic) {
  * are as expected.
  */
 TEST(Sdf, sdf_constructor_screw) {
-  auto model = GetSdf(kSdfPath + std::string("/test/simple_screw_joint.sdf"),
+  auto model = GetSdf(kSdfPath + std::string("test/simple_screw_joint.sdf"),
                       "simple_screw_joint_sdf");
 
   LinkSharedPtr l0 = LinkFromSdf(0, *model.LinkByName("link_0"));
@@ -563,7 +561,7 @@ TEST(Sdf, sdf_constructor_screw) {
 // that all transforms, link/joint properties, etc. are correct.
 TEST(Robot, simple_urdf) {
   // Load urdf file into sdf::Model
-  auto simple_urdf = GetSdf(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+  auto simple_urdf = GetSdf(kUrdfPath + std::string("test/simple_urdf.urdf"));
 
   LinkSharedPtr l1 = LinkFromSdf(1, *simple_urdf.LinkByName("l1"));
   LinkSharedPtr l2 = LinkFromSdf(2, *simple_urdf.LinkByName("l2"));
@@ -580,7 +578,7 @@ TEST(Robot, simple_urdf) {
 
   // Initialize Robot instance.
   auto simple_robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/test/simple_urdf.urdf"));
+      CreateRobotFromFile(kUrdfPath + std::string("test/simple_urdf.urdf"));
 
   EXPECT(assert_equal(1, simple_robot.link("l1")->numJoints()));
   EXPECT(assert_equal(1, simple_robot.link("l2")->numJoints()));
@@ -616,7 +614,7 @@ TEST(Robot, simple_urdf) {
 
 // Check the links in the simple RR robot.
 TEST(Sdf, sdf_constructor) {
-  std::string file_path = kSdfPath + std::string("/test/simple_rr.sdf");
+  std::string file_path = kSdfPath + std::string("test/simple_rr.sdf");
   std::string model_name = "simple_rr_sdf";
   Link l0 = Link(*LinkFromSdf(0, "link_0", file_path, model_name));
   Link l1 = Link(*LinkFromSdf(1, "link_1", file_path, model_name));

--- a/tests/testSpiderWalking.cpp
+++ b/tests/testSpiderWalking.cpp
@@ -63,7 +63,7 @@ Trajectory getTrajectory(const Robot& robot, size_t repeat) {
 TEST(testSpiderWalking, WholeEnchilada) {
   // Load Stephanie's robot robot (alt version, created by Tarushree/Disha).
   Robot robot =
-      CreateRobotFromFile(kSdfPath + std::string("/spider_alt.sdf"), "spider");
+      CreateRobotFromFile(kSdfPath + std::string("spider_alt.sdf"), "spider");
 
   double sigma_dynamics = 1e-5;    // std of dynamics constraints.
   double sigma_objectives = 1e-6;  // std of additional objectives.
@@ -152,7 +152,7 @@ TEST(testSpiderWalking, WholeEnchilada) {
   // Note, expects space after comma in csv or won't work.
   std::string key, comm;
   double expected;
-  std::string filename = kTestPath + std::string("/testSpiderWalking.csv");
+  std::string filename = kTestPath + std::string("testSpiderWalking.csv");
   std::ifstream is(filename.c_str());
   is >> key >> expected;
   double actual = graph.error(init_vals);

--- a/tests/testStatics.cpp
+++ b/tests/testStatics.cpp
@@ -27,7 +27,7 @@ constexpr double kTol = 1e-6;
 namespace example {
 constexpr double g = 9.8;
 const Robot robot = gtdynamics::CreateRobotFromFile(
-    kSdfPath + std::string("/test/four_bar_linkage.sdf"));
+    kSdfPath + std::string("test/four_bar_linkage.sdf"));
 Vector3 gravity(0, 0, -g);
 }  // namespace example
 

--- a/tests/testTrajectory.cpp
+++ b/tests/testTrajectory.cpp
@@ -39,7 +39,7 @@ class TrajectoryTest : public Trajectory {
 
 TEST(Trajectory, Intersection) {
   Robot robot =
-      CreateRobotFromFile(kSdfPath + std::string("/spider.sdf"), "spider");
+      CreateRobotFromFile(kSdfPath + std::string("spider.sdf"), "spider");
 
   using namespace walk_cycle_example;
   TrajectoryTest traj;
@@ -57,7 +57,7 @@ TEST(Trajectory, Intersection) {
 TEST(Trajectory, error) {
   using namespace walk_cycle_example;
   Robot robot =
-      CreateRobotFromFile(kSdfPath + std::string("/spider.sdf"), "spider");
+      CreateRobotFromFile(kSdfPath + std::string("spider.sdf"), "spider");
 
   // Initialize Trajectory
   size_t repeat = 3;

--- a/tests/testWalkCycle.cpp
+++ b/tests/testWalkCycle.cpp
@@ -25,7 +25,7 @@ using gtsam::Point3;
 
 TEST(WalkCycle, contactPoints) {
   Robot robot =
-      CreateRobotFromFile(kSdfPath + std::string("/spider.sdf"), "spider");
+      CreateRobotFromFile(kSdfPath + std::string("spider.sdf"), "spider");
 
   using namespace walk_cycle_example;
   auto walk_cycle_phases = walk_cycle.phases();
@@ -39,7 +39,7 @@ TEST(WalkCycle, contactPoints) {
 
 TEST(WalkCycle, objectives) {
   Robot robot =
-      CreateRobotFromFile(kUrdfPath + std::string("/vision60.urdf"), "spider");
+      CreateRobotFromFile(kUrdfPath + std::string("vision60.urdf"), "spider");
   EXPECT_LONGS_EQUAL(13, robot.numLinks());
 
   constexpr size_t num_time_steps = 5;

--- a/tests/walkCycleExample.h
+++ b/tests/walkCycleExample.h
@@ -19,7 +19,7 @@ namespace gtdynamics {
 namespace walk_cycle_example {
 
 Robot robot =
-  CreateRobotFromFile(kSdfPath + std::string("/spider.sdf"), "spider");
+  CreateRobotFromFile(kSdfPath + std::string("spider.sdf"), "spider");
 
 // First phase
 constexpr size_t num_time_steps = 2;


### PR DESCRIPTION
The need for the leading slash (e.g. `/tests/simple_rr.sdf`) is counter-intuitive and error-prone.
This PR fixes that.