### PR TITLE
Make factors and others type-agnostic (precursor to SphericalJoints)

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -36,9 +36,8 @@ typedef gtdynamics::JointMeasurementFactor<gtdynamics::RevoluteJoint> RevoluteJo
 
 #include <gtdynamics/factors/PoseFactor.h>
 class PoseFactor : gtsam::NonlinearFactor {
-  PoseFactor(gtsam::Key wTp_key, gtsam::Key wTc_key, gtsam::Key q_key,
-             const gtsam::noiseModel::Base* cost_model,
-             const gtdynamics::Joint* joint);
+  PoseFactor(const gtsam::noiseModel::Base *cost_model,
+             const gtdynamics::Joint *joint, int k = 0);
 
   void print(const string &s="",
              const gtsam::KeyFormatter &keyFormatter=gtdynamics::GTDKeyFormatter);
@@ -93,10 +92,8 @@ class ContactPointFactor : gtsam::NoiseModelFactor {
 
 #include <gtdynamics/factors/TwistFactor.h>
 class TwistFactor : gtsam::NonlinearFactor {
-  TwistFactor(gtsam::Key twistP_key, gtsam::Key twistC_key, gtsam::Key q_key,
-              gtsam::Key qVel_key,
-              const gtsam::noiseModel::Base* cost_model,
-              const gtdynamics::Joint* joint);
+  TwistFactor(const gtsam::noiseModel::Base *cost_model,
+              const gtdynamics::Joint *joint, int k = 0);
 
   void print(const string &s="",
              const gtsam::KeyFormatter &keyFormatter=gtdynamics::GTDKeyFormatter);
@@ -104,10 +101,8 @@ class TwistFactor : gtsam::NonlinearFactor {
 
 #include <gtdynamics/factors/TwistAccelFactor.h>
 class TwistAccelFactor : gtsam::NonlinearFactor {
-  TwistAccelFactor(gtsam::Key twist_key_c, gtsam::Key twistAccel_key_p, gtsam::Key twistAccel_key_c,
-              gtsam::Key q_key, gtsam::Key qVel_key, gtsam::Key qAccel_key,
-              const gtsam::noiseModel::Base* cost_model,
-              const gtdynamics::JointTyped* joint);
+  TwistAccelFactor(const gtsam::noiseModel::Base *cost_model,
+                   const gtdynamics::Joint *joint, int k = 0);
 
   void print(const string &s="",
              const gtsam::KeyFormatter &keyFormatter=gtdynamics::GTDKeyFormatter);
@@ -116,7 +111,7 @@ class TwistAccelFactor : gtsam::NonlinearFactor {
 #include <gtdynamics/factors/TorqueFactor.h>
 class TorqueFactor : gtsam::NonlinearFactor {
   TorqueFactor(const gtsam::noiseModel::Base *cost_model,
-               const gtdynamics::JointTyped *joint, size_t k=0);
+               const gtdynamics::Joint *joint, size_t k = 0);
 
   void print(const string &s="",
              const gtsam::KeyFormatter &keyFormatter=gtdynamics::GTDKeyFormatter);
@@ -145,7 +140,7 @@ class WrenchFactor : gtsam::NonlinearFactor {
 #include <gtdynamics/factors/WrenchEquivalenceFactor.h>
 class WrenchEquivalenceFactor : gtsam::NonlinearFactor{
   WrenchEquivalenceFactor(const gtsam::noiseModel::Base *cost_model,
-                          gtdynamics::JointTyped *joint, size_t k = 0);
+                          gtdynamics::Joint *joint, size_t k = 0);
   void print(const string &s="",
              const gtsam::KeyFormatter &keyFormatter=gtdynamics::GTDKeyFormatter);
 };
@@ -153,7 +148,8 @@ class WrenchEquivalenceFactor : gtsam::NonlinearFactor{
 #include <gtdynamics/factors/WrenchPlanarFactor.h>
 class WrenchPlanarFactor : gtsam::NonlinearFactor {
   WrenchPlanarFactor(const gtsam::noiseModel::Base *cost_model,
-                     Vector planar_axis, gtdynamics::JointTyped *joint, size_t k=0);
+                     Vector planar_axis, gtdynamics::Joint *joint,
+                     size_t k = 0);
   void print(const string &s="",
              const gtsam::KeyFormatter &keyFormatter=gtdynamics::GTDKeyFormatter);
 };

--- a/gtdynamics/dynamics/DynamicsGraph.cpp
+++ b/gtdynamics/dynamics/DynamicsGraph.cpp
@@ -338,13 +338,11 @@ gtsam::NonlinearFactorGraph DynamicsGraph::dynamicsFactors(
   // TODO(frank): sort out const shared ptr mess
   for (auto &&joint : robot.joints()) {
     auto j = joint->id(), child_id = joint->child()->id();
-    auto const_joint = boost::static_pointer_cast<const JointTyped>(joint);
-    graph.emplace_shared<WrenchEquivalenceFactor>(opt_.f_cost_model,
-                                                  const_joint, k);
-    graph.emplace_shared<TorqueFactor>(opt_.t_cost_model, const_joint, k);
+    graph.emplace_shared<WrenchEquivalenceFactor>(opt_.f_cost_model, joint, k);
+    graph.emplace_shared<TorqueFactor>(opt_.t_cost_model, joint, k);
     if (planar_axis_)
       graph.emplace_shared<WrenchPlanarFactor>(opt_.planar_cost_model,
-                                               *planar_axis_, const_joint, k);
+                                               *planar_axis_, joint, k);
   }
   return graph;
 }

--- a/gtdynamics/dynamics/DynamicsGraph.cpp
+++ b/gtdynamics/dynamics/DynamicsGraph.cpp
@@ -240,11 +240,7 @@ gtsam::NonlinearFactorGraph DynamicsGraph::vFactors(
                                      gtsam::Z_6x1, opt_.bv_cost_model);
 
   for (auto &&joint : robot.joints())
-    graph.emplace_shared<TwistFactor>(internal::TwistKey(joint->parent()->id(), t),
-                                    internal::TwistKey(joint->child()->id(), t),
-                                    internal::JointAngleKey(joint->id(), t),
-                                    internal::JointVelKey(joint->id(), t),
-                                    opt_.v_cost_model, joint);
+    graph.emplace_shared<TwistFactor>(opt_.v_cost_model, joint, t);
 
   // Add contact factors.
   if (contact_points) {

--- a/gtdynamics/dynamics/DynamicsGraph.cpp
+++ b/gtdynamics/dynamics/DynamicsGraph.cpp
@@ -261,13 +261,7 @@ gtsam::NonlinearFactorGraph DynamicsGraph::aFactors(
       graph.addPrior<gtsam::Vector6>(internal::TwistAccelKey(link->id(), t),
                                      gtsam::Z_6x1, opt_.ba_cost_model);
   for (auto &&joint : robot.joints())
-    graph.emplace_shared<TwistAccelFactor>(
-      internal::TwistKey(joint->child()->id(), t),
-      internal::TwistAccelKey(joint->parent()->id(), t),
-      internal::TwistAccelKey(joint->child()->id(), t),
-      internal::JointAngleKey(joint->id(), t), internal::JointVelKey(joint->id(), t),
-      internal::JointAccelKey(joint->id(), t), opt_.a_cost_model,
-      boost::static_pointer_cast<const JointTyped>(joint));
+    graph.emplace_shared<TwistAccelFactor>(opt_.a_cost_model, joint, t);
 
   // Add contact factors.
   if (contact_points) {

--- a/gtdynamics/dynamics/DynamicsGraph.cpp
+++ b/gtdynamics/dynamics/DynamicsGraph.cpp
@@ -204,10 +204,7 @@ gtsam::NonlinearFactorGraph DynamicsGraph::qFactors(
 
   // TODO(frank): call Kinematics::graph<Slice> instead
   for (auto &&joint : robot.joints()) {
-    graph.emplace_shared<PoseFactor>(
-        internal::PoseKey(joint->parent()->id(), k),
-        internal::PoseKey(joint->child()->id(), k),
-        internal::JointAngleKey(joint->id(), k), opt_.p_cost_model, joint);
+    graph.emplace_shared<PoseFactor>(opt_.p_cost_model, joint, k);
   }
 
   // TODO(frank): whoever write this should clean up this mess.

--- a/gtdynamics/factors/JointLimitDoubleFactor.h
+++ b/gtdynamics/factors/JointLimitDoubleFactor.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-#include "gtdynamics/universal_robot/JointTyped.h"
+#include "gtdynamics/universal_robot/Joint.h"
 
 namespace gtdynamics {
 

--- a/gtdynamics/factors/JointLimitDoubleFactor.h
+++ b/gtdynamics/factors/JointLimitDoubleFactor.h
@@ -6,7 +6,7 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file  JointLimitFactor.h
+ * @file  JointLimitDoubleFactor.h
  * @brief apply joint limit
  * @author: Frank Dellaert, Mandy Xie, Stephanie McCormick, Varun Agrawal
  */
@@ -29,16 +29,14 @@
 namespace gtdynamics {
 
 /**
- * JointLimitFactor is a class which enforces joint angle, velocity,
- * acceleration and torque value to be within limi
+ * JointLimitDoubleFactor is a class which enforces joint angle, velocity,
+ * acceleration and torque value to be within limits
  */
-class JointLimitFactor
-    : public gtsam::NoiseModelFactor1<JointTyped::JointCoordinateType> {
+class JointLimitDoubleFactor : public gtsam::NoiseModelFactor1<double> {
  private:
-  using JointCoordinateType = JointTyped::JointCoordinateType;
-  using This = JointLimitFactor;
-  using Base = gtsam::NoiseModelFactor1<JointCoordinateType>;
-  JointCoordinateType low_, high_;
+  using This = JointLimitDoubleFactor;
+  using Base = gtsam::NoiseModelFactor1<double>;
+  double low_, high_;
 
  public:
   /**
@@ -49,16 +47,16 @@ class JointLimitFactor
    * @param upper_limit joint upper limit
    * @param limit_threshold joint limit threshold
    */
-  JointLimitFactor(gtsam::Key q_key,
-                   const gtsam::noiseModel::Base::shared_ptr &cost_model,
-                   JointCoordinateType lower_limit,
-                   JointCoordinateType upper_limit,
-                   JointCoordinateType limit_threshold)
+  JointLimitDoubleFactor(gtsam::Key q_key,
+                         const gtsam::noiseModel::Base::shared_ptr &cost_model,
+                         double lower_limit,
+                         double upper_limit,
+                         double limit_threshold)
       : Base(cost_model, q_key),
         low_(lower_limit + limit_threshold),
         high_(upper_limit - limit_threshold) {}
 
-  virtual ~JointLimitFactor() {}
+  virtual ~JointLimitDoubleFactor() {}
 
  public:
   /**
@@ -72,7 +70,7 @@ class JointLimitFactor
    * @param q joint value
    */
   gtsam::Vector evaluateError(
-      const JointCoordinateType &q,
+      const double &q,
       boost::optional<gtsam::Matrix &> H_q = boost::none) const override {
     if (q < low_) {
       if (H_q) *H_q = -gtsam::I_1x1;
@@ -96,7 +94,7 @@ class JointLimitFactor
   void print(const std::string &s = "",
              const gtsam::KeyFormatter &keyFormatter =
                  gtsam::DefaultKeyFormatter) const override {
-    std::cout << s << "JointLimitFactor" << std::endl;
+    std::cout << s << "JointLimitDoubleFactor" << std::endl;
     Base::print("", keyFormatter);
   }
 

--- a/gtdynamics/factors/PoseFactor.h
+++ b/gtdynamics/factors/PoseFactor.h
@@ -28,8 +28,6 @@
 
 namespace gtdynamics {
 
-using boost::assign::cref_list_of;
-
 /**
  * PoseFactor is a three-way nonlinear factor between a joint's parent link
  * pose, child link pose, and the joint angle relating the two poses.
@@ -56,31 +54,11 @@ class PoseFactor : public gtsam::NoiseModelFactor {
   PoseFactor(const gtsam::SharedNoiseModel &cost_model,
              const JointConstSharedPtr &joint, int time)
       : Base(cost_model,
-             cref_list_of<3>(
+             boost::assign::cref_list_of<3>(
                  internal::PoseKey(joint->parent()->id(), time).key())(
                  internal::PoseKey(joint->child()->id(), time).key())(
                  internal::JointAngleKey(joint->id(), time).key())),
         t_(time),
-        joint_(joint) {}
-
-  /**
-   * Create single factor relating this link's pose (COM) with previous one.
-   *
-   * Please use the joint based constructor above if possible.
-   *
-   * @param wTp_key Key for parent link's CoM pose in world frame.
-   * @param wTc_key Key for child link's CoM pose in world frame.
-   * @param q_key Key for joint value.
-   * @param cost_model The noise model for this factor.
-   * @param joint The joint connecting the two poses
-   */
-  PoseFactor(DynamicsSymbol wTp_key, DynamicsSymbol wTc_key,
-             DynamicsSymbol q_key,
-             const gtsam::noiseModel::Base::shared_ptr &cost_model,
-             JointConstSharedPtr joint)
-      : Base(cost_model,
-             cref_list_of<3>(wTp_key.key())(wTc_key.key())(q_key.key())),
-        t_(wTp_key.time()),
         joint_(joint) {}
 
   virtual ~PoseFactor() {}

--- a/gtdynamics/factors/PreintegratedContactFactors.h
+++ b/gtdynamics/factors/PreintegratedContactFactors.h
@@ -24,7 +24,7 @@
 #include <memory>
 #include <string>
 
-#include "gtdynamics/universal_robot/JointTyped.h"
+#include "gtdynamics/universal_robot/Joint.h"
 #include "gtdynamics/universal_robot/Link.h"
 
 namespace gtdynamics {

--- a/gtdynamics/factors/TorqueFactor.h
+++ b/gtdynamics/factors/TorqueFactor.h
@@ -82,10 +82,12 @@ class TorqueFactor : public gtsam::NoiseModelFactor {
 
     if (H) {
       (*H)[1] = -gtsam::Matrix::Identity(torque.size(), torque.size());
-      return joint_->transformWrenchToTorque(joint_->child(), wrench, (*H)[0]) -
+      return joint_->transformWrenchToTorqueVector(joint_->child(), wrench,
+                                                   (*H)[0]) -
              torque;
     } else {
-      return joint_->transformWrenchToTorque(joint_->child(), wrench) - torque;
+      return joint_->transformWrenchToTorqueVector(joint_->child(), wrench) -
+             torque;
     }
   }
 

--- a/gtdynamics/factors/TorqueFactor.h
+++ b/gtdynamics/factors/TorqueFactor.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <string>
 
-#include "gtdynamics/universal_robot/JointTyped.h"
+#include "gtdynamics/universal_robot/Joint.h"
 #include "gtdynamics/universal_robot/Link.h"
 #include "gtdynamics/utils/values.h"
 

--- a/gtdynamics/factors/TwistAccelFactor.h
+++ b/gtdynamics/factors/TwistAccelFactor.h
@@ -24,7 +24,7 @@
 #include <memory>
 #include <string>
 
-#include "gtdynamics/universal_robot/JointTyped.h"
+#include "gtdynamics/universal_robot/Joint.h"
 #include "gtdynamics/universal_robot/Link.h"
 
 namespace gtdynamics {

--- a/gtdynamics/factors/TwistAccelFactor.h
+++ b/gtdynamics/factors/TwistAccelFactor.h
@@ -19,11 +19,13 @@
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 
+#include <boost/assign/list_of.hpp>
 #include <boost/optional.hpp>
 #include <memory>
 #include <string>
 
 #include "gtdynamics/universal_robot/JointTyped.h"
+#include "gtdynamics/universal_robot/Link.h"
 
 namespace gtdynamics {
 
@@ -31,21 +33,13 @@ namespace gtdynamics {
  * TwistAccelFactor is a six-way nonlinear factor which enforces relation
  * between acceleration on previous link and this link.
  */
-class TwistAccelFactor
-    : public gtsam::NoiseModelFactor6<
-          gtsam::Vector6, gtsam::Vector6, gtsam::Vector6,
-          JointTyped::JointCoordinate, JointTyped::JointVelocity,
-          JointTyped::JointAcceleration> {
+class TwistAccelFactor : public gtsam::NoiseModelFactor {
  private:
-  using JointCoordinate = JointTyped::JointCoordinate;
-  using JointVelocity = JointTyped::JointVelocity;
-  using JointAcceleration = JointTyped::JointVelocity;
   using This = TwistAccelFactor;
-  using Base = gtsam::NoiseModelFactor6<gtsam::Vector6, gtsam::Vector6,
-                                        gtsam::Vector6, JointCoordinate,
-                                        JointVelocity, JointAcceleration>;
-  using JointTypedConstSharedPtr = boost::shared_ptr<const JointTyped>;
-  JointTypedConstSharedPtr joint_;
+  using Base = gtsam::NoiseModelFactor;
+
+  JointConstSharedPtr joint_;
+  int t_;
 
  public:
   /**
@@ -57,45 +51,55 @@ class TwistAccelFactor
    *
    * @param joint JointConstSharedPtr to the joint
    */
-  TwistAccelFactor(gtsam::Key twist_key_c, gtsam::Key twistAccel_key_p,
-                   gtsam::Key twistAccel_key_c, gtsam::Key q_key,
-                   gtsam::Key qVel_key, gtsam::Key qAccel_key,
-                   const gtsam::noiseModel::Base::shared_ptr &cost_model,
-                   JointTypedConstSharedPtr joint)
-      : Base(cost_model, twist_key_c, twistAccel_key_p, twistAccel_key_c, q_key,
-             qVel_key, qAccel_key),
-        joint_(joint) {}
+  TwistAccelFactor(const gtsam::noiseModel::Base::shared_ptr &cost_model,
+                   JointConstSharedPtr joint, int t)
+      : Base(cost_model,
+             boost::assign::cref_list_of<6>(
+                 internal::TwistKey(joint->child()->id(), t).key())(
+                 internal::TwistAccelKey(joint->parent()->id(), t).key())(
+                 internal::TwistAccelKey(joint->child()->id(), t).key())(
+                 internal::JointAngleKey(joint->id(), t).key())(
+                 internal::JointVelKey(joint->id(), t).key())(
+                 internal::JointAccelKey(joint->id(), t).key())),
+        joint_(joint),
+        t_(t) {}
   virtual ~TwistAccelFactor() {}
 
  private:
  public:
   /**
    * Evaluate twist acceleration errors
-   * @param twistAccel_p twist acceleration on parent link
-   * @param twistAccel_c twist acceleration on child link
-   * @param twist_c twist on child link
-   * @param q joint coordination
-   * @param qVel joint velocity
-   * @param qAccel joint acceleration
    */
-  gtsam::Vector evaluateError(
-      const gtsam::Vector6 &twist_c, const gtsam::Vector6 &twistAccel_p,
-      const gtsam::Vector6 &twistAccel_c, const JointCoordinate &q,
-      const JointAcceleration &qVel, const JointAcceleration &qAccel,
-      boost::optional<gtsam::Matrix &> H_twist_c = boost::none,
-      boost::optional<gtsam::Matrix &> H_twistAccel_p = boost::none,
-      boost::optional<gtsam::Matrix &> H_twistAccel_c = boost::none,
-      boost::optional<gtsam::Matrix &> H_q = boost::none,
-      boost::optional<gtsam::Matrix &> H_qVel = boost::none,
-      boost::optional<gtsam::Matrix &> H_qAccel = boost::none) const override {
-    auto error =
-        joint_->transformTwistAccelTo(joint_->child(), q, qVel, qAccel,
-                                      twist_c, twistAccel_p, H_q, H_qVel,
-                                      H_qAccel, H_twist_c, H_twistAccel_p) -
-        twistAccel_c;
+  gtsam::Vector unwhitenedError(const gtsam::Values &x,
+                                boost::optional<std::vector<gtsam::Matrix> &>
+                                    H = boost::none) const override {
+    const gtsam::Vector6 &twist_c = x.at<gtsam::Vector6>(keys_[0]);
+    const gtsam::Vector6 &twistAccel_p = x.at<gtsam::Vector6>(keys_[1]);
+    const gtsam::Vector6 &twistAccel_c = x.at<gtsam::Vector6>(keys_[2]);
+    gtsam::Matrix6 H_twist_c, H_twistAccel_p;
+    gtsam::Matrix H_q, H_qVel, H_qAccel;
+    boost::optional<gtsam::Matrix &> H_q_ref = boost::none,
+                                     H_qVel_ref = boost::none,
+                                     H_qAccel_ref = boost::none;
+    if (H) {
+      H_q_ref = H_q;
+      H_qVel_ref = H_qVel;
+      H_qAccel_ref = H_qAccel;
+    }
 
-    if (H_twistAccel_c) {
-      *H_twistAccel_c = -gtsam::I_6x6;
+    auto error = joint_->transformTwistAccelTo(
+                     t_, joint_->child(), x, twist_c, twistAccel_p,  //
+                     H_q_ref, H_qVel_ref, H_qAccel_ref,
+                     H ? &H_twist_c : nullptr, H ? &H_twistAccel_p : nullptr) -
+                 twistAccel_c;
+
+    if (H) {
+      (*H)[0] = H_twist_c;
+      (*H)[1] = H_twistAccel_p;
+      (*H)[2] = -gtsam::I_6x6;  // H_twistAccel_c
+      (*H)[3] = H_q;
+      (*H)[4] = H_qVel;
+      (*H)[5] = H_qAccel;
     }
 
     return error;

--- a/gtdynamics/factors/TwistFactor.h
+++ b/gtdynamics/factors/TwistFactor.h
@@ -22,7 +22,7 @@
 #include <boost/optional.hpp>
 #include <string>
 
-#include "gtdynamics/universal_robot/JointTyped.h"
+#include "gtdynamics/universal_robot/Joint.h"
 
 namespace gtdynamics {
 

--- a/gtdynamics/factors/WrenchPlanarFactor.h
+++ b/gtdynamics/factors/WrenchPlanarFactor.h
@@ -20,7 +20,7 @@
 #include <boost/optional.hpp>
 #include <string>
 
-#include "gtdynamics/universal_robot/JointTyped.h"
+#include "gtdynamics/universal_robot/Joint.h"
 #include "gtdynamics/universal_robot/Link.h"
 #include "gtdynamics/utils/utils.h"
 #include "gtdynamics/utils/values.h"
@@ -56,8 +56,7 @@ class WrenchPlanarFactor : public gtsam::NoiseModelFactor1<gtsam::Vector6> {
    */
   WrenchPlanarFactor(const gtsam::noiseModel::Base::shared_ptr &cost_model,
                      gtsam::Vector3 planar_axis,
-                     const boost::shared_ptr<const JointTyped> &joint,
-                     size_t k = 0)
+                     const JointConstSharedPtr &joint, size_t k = 0)
       : WrenchPlanarFactor(
             cost_model, planar_axis,
             internal::WrenchKey(joint->child()->id(), joint->id(), k)) {}

--- a/gtdynamics/kinematics/KinematicsSlice.cpp
+++ b/gtdynamics/kinematics/KinematicsSlice.cpp
@@ -42,10 +42,7 @@ NonlinearFactorGraph Kinematics::graph<Slice>(const Slice& slice,
   // Constrain kinematics at joints.
   for (auto&& joint : robot.joints()) {
     const auto j = joint->id();
-    graph.emplace_shared<PoseFactor>(
-        internal::PoseKey(joint->parent()->id(), slice.k),
-        internal::PoseKey(joint->child()->id(), slice.k),
-        internal::JointAngleKey(j, slice.k), p_->p_cost_model, joint);
+    graph.emplace_shared<PoseFactor>(p_->p_cost_model, joint, slice.k);
   }
 
   return graph;

--- a/gtdynamics/statics/StaticsSlice.cpp
+++ b/gtdynamics/statics/StaticsSlice.cpp
@@ -44,9 +44,7 @@ gtsam::NonlinearFactorGraph Statics::torqueFactors(const Slice& slice,
                                                    const Robot& robot) const {
   gtsam::NonlinearFactorGraph graph;
   for (auto&& joint : robot.joints()) {
-    graph.emplace_shared<TorqueFactor>(
-        p_->t_cost_model, boost::static_pointer_cast<const JointTyped>(joint),
-        slice.k);
+    graph.emplace_shared<TorqueFactor>(p_->t_cost_model, joint, slice.k);
   }
   return graph;
 }

--- a/gtdynamics/statics/StaticsSlice.cpp
+++ b/gtdynamics/statics/StaticsSlice.cpp
@@ -33,9 +33,8 @@ gtsam::NonlinearFactorGraph Statics::wrenchEquivalenceFactors(
     const Slice& slice, const Robot& robot) const {
   gtsam::NonlinearFactorGraph graph;
   for (auto&& joint : robot.joints()) {
-    graph.emplace_shared<WrenchEquivalenceFactor>(
-        p_->f_cost_model, boost::static_pointer_cast<const JointTyped>(joint),
-        slice.k);
+    graph.emplace_shared<WrenchEquivalenceFactor>(p_->f_cost_model, joint,
+                                                  slice.k);
   }
   return graph;
 }
@@ -55,8 +54,7 @@ gtsam::NonlinearFactorGraph Statics::wrenchPlanarFactors(
   if (p_->planar_axis)
     for (auto&& joint : robot.joints()) {
       graph.emplace_shared<WrenchPlanarFactor>(
-          p_->planar_cost_model, *p_->planar_axis,
-          boost::static_pointer_cast<const JointTyped>(joint), slice.k);
+          p_->planar_cost_model, *p_->planar_axis, joint, slice.k);
     }
   return graph;
 }

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -277,6 +277,12 @@ class Joint : public boost::enable_shared_from_this<Joint> {
       gtsam::OptionalJacobian<6, 6> H_other_twist_accel =
           boost::none) const = 0;
 
+  /// Abstract method. Return the torque on this joint given the wrench
+  virtual gtsam::Vector transformWrenchToTorque(
+      const LinkSharedPtr &link,
+      boost::optional<gtsam::Vector6> wrench = boost::none,
+      gtsam::OptionalJacobian<-1, -1> H_wrench = boost::none) const = 0;
+
   /// Abstract method. Returns forward dynamics priors on torque
   virtual gtsam::GaussianFactorGraph linearFDPriors(
       size_t t, const gtsam::Values &torques,

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -278,7 +278,7 @@ class Joint : public boost::enable_shared_from_this<Joint> {
           boost::none) const = 0;
 
   /// Abstract method. Return the torque on this joint given the wrench
-  virtual gtsam::Vector transformWrenchToTorque(
+  virtual gtsam::Vector transformWrenchToTorqueVector(
       const LinkSharedPtr &link,
       boost::optional<gtsam::Vector6> wrench = boost::none,
       gtsam::OptionalJacobian<-1, -1> H_wrench = boost::none) const = 0;

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -236,7 +236,7 @@ class Joint : public boost::enable_shared_from_this<Joint> {
    */
   virtual Pose3 relativePoseOf(
       const LinkSharedPtr &link2, const gtsam::Values &q, size_t t = 0,
-      boost::optional<gtsam::Matrix &> H_q = boost::none) const = 0;
+      gtsam::OptionalJacobian<-1, -1> H_q = boost::none) const = 0;
 
   /**
    * Return the world pose of the specified link [link2], given

--- a/gtdynamics/universal_robot/JointTyped.h
+++ b/gtdynamics/universal_robot/JointTyped.h
@@ -174,8 +174,10 @@ public:
    */
   Pose3 relativePoseOf(
       const LinkSharedPtr &link2, const gtsam::Values &q, size_t t = 0,
-      boost::optional<gtsam::Matrix &> H_q = boost::none) const override {
-    return relativePoseOf(link2, JointAngle<JointCoordinate>(q, id(), t), H_q);
+      gtsam::OptionalJacobian<-1, -1> H_q = boost::none) const override {
+    return H_q ? relativePoseOf(link2, JointAngle<JointCoordinate>(q, id(), t),
+                                *H_q)
+               : relativePoseOf(link2, JointAngle<JointCoordinate>(q, id(), t));
   }
 
   /// Joint-induced twist in child frame

--- a/gtdynamics/universal_robot/JointTyped.h
+++ b/gtdynamics/universal_robot/JointTyped.h
@@ -112,13 +112,6 @@ public:
       boost::optional<gtsam::Vector6> wrench = boost::none,
       gtsam::OptionalJacobian<N, 6> H_wrench = boost::none) const = 0;
 
-  /// Calculate AdjointMap jacobian w.r.t. joint coordinate q.
-  /// TODO(gerry + stephanie): change to calculate the jacobian of Ad_T(v) wrt T
-  /// rather than jacobian of Ad_T wrt q (and put in utils or PR to GTSAM)
-  virtual gtsam::Matrix6
-  AdjointMapJacobianJointAngle(const LinkSharedPtr &link,
-                               JointCoordinate q) const = 0;
-
   ///@}
   /**
    * @name generic

--- a/gtdynamics/universal_robot/JointTyped.h
+++ b/gtdynamics/universal_robot/JointTyped.h
@@ -106,8 +106,8 @@ public:
       gtsam::OptionalJacobian<6, 6> H_other_twist_accel =
           boost::none) const = 0;
 
-  /// Abstract method. Return the torque on this joint given the wrench
-  virtual JointTorque transformWrenchToTorque(
+  /// Abstract method. Return the torque on this joint given the wrench.
+  virtual JointTorque transformWrenchToTorqueTyped(
       const LinkSharedPtr &link,
       boost::optional<gtsam::Vector6> wrench = boost::none,
       gtsam::OptionalJacobian<N, 6> H_wrench = boost::none) const = 0;
@@ -237,6 +237,18 @@ public:
                                  JointAccel<JointAcceleration>(values, id(), t),
                                  this_twist, other_twist_accel, H_q, H_q_dot,
                                  H_q_ddot, H_this_twist, H_other_twist_accel);
+  }
+
+  /// Return the torque on this joint given the wrench.
+  gtsam::Vector transformWrenchToTorque(
+      const LinkSharedPtr &link,
+      boost::optional<gtsam::Vector6> wrench = boost::none,
+      gtsam::OptionalJacobian<-1, -1> H_wrench =
+          boost::none) const final override {
+    gtsam::Vector ret(static_cast<int>(N));  // idk why int cast is needed
+    ret << (H_wrench ? transformWrenchToTorqueTyped(link, wrench, *H_wrench)
+                     : transformWrenchToTorqueTyped(link, wrench));
+    return ret;
   }
 };
 

--- a/gtdynamics/universal_robot/JointTyped.h
+++ b/gtdynamics/universal_robot/JointTyped.h
@@ -107,7 +107,7 @@ public:
           boost::none) const = 0;
 
   /// Abstract method. Return the torque on this joint given the wrench.
-  virtual JointTorque transformWrenchToTorqueTyped(
+  virtual JointTorque transformWrenchToTorque(
       const LinkSharedPtr &link,
       boost::optional<gtsam::Vector6> wrench = boost::none,
       gtsam::OptionalJacobian<N, 6> H_wrench = boost::none) const = 0;
@@ -240,14 +240,14 @@ public:
   }
 
   /// Return the torque on this joint given the wrench.
-  gtsam::Vector transformWrenchToTorque(
+  gtsam::Vector transformWrenchToTorqueVector(
       const LinkSharedPtr &link,
       boost::optional<gtsam::Vector6> wrench = boost::none,
       gtsam::OptionalJacobian<-1, -1> H_wrench =
           boost::none) const final override {
     gtsam::Vector ret(static_cast<int>(N));  // idk why int cast is needed
-    ret << (H_wrench ? transformWrenchToTorqueTyped(link, wrench, *H_wrench)
-                     : transformWrenchToTorqueTyped(link, wrench));
+    ret << (H_wrench ? transformWrenchToTorque(link, wrench, *H_wrench)
+                     : transformWrenchToTorque(link, wrench));
     return ret;
   }
 };

--- a/gtdynamics/universal_robot/ScrewJointBase.cpp
+++ b/gtdynamics/universal_robot/ScrewJointBase.cpp
@@ -143,7 +143,7 @@ Vector6 ScrewJointBase::transformTwistAccelTo(
 }
 
 /* ************************************************************************* */
-ScrewJointBase::JointTorque ScrewJointBase::transformWrenchToTorqueTyped(
+ScrewJointBase::JointTorque ScrewJointBase::transformWrenchToTorque(
     const LinkSharedPtr &link, boost::optional<Vector6> wrench,
     gtsam::OptionalJacobian<1, 6> H_wrench) const {
   auto screw_axis_ = screwAxis(link);

--- a/gtdynamics/universal_robot/ScrewJointBase.cpp
+++ b/gtdynamics/universal_robot/ScrewJointBase.cpp
@@ -143,7 +143,7 @@ Vector6 ScrewJointBase::transformTwistAccelTo(
 }
 
 /* ************************************************************************* */
-ScrewJointBase::JointTorque ScrewJointBase::transformWrenchToTorque(
+ScrewJointBase::JointTorque ScrewJointBase::transformWrenchToTorqueTyped(
     const LinkSharedPtr &link, boost::optional<Vector6> wrench,
     gtsam::OptionalJacobian<1, 6> H_wrench) const {
   auto screw_axis_ = screwAxis(link);

--- a/gtdynamics/universal_robot/ScrewJointBase.cpp
+++ b/gtdynamics/universal_robot/ScrewJointBase.cpp
@@ -21,7 +21,7 @@
 
 #include "gtdynamics/universal_robot/ScrewJointBase.h"
 
-#include "gtdynamics/factors/JointLimitFactor.h"
+#include "gtdynamics/factors/JointLimitDoubleFactor.h"
 #include "gtdynamics/universal_robot/Link.h"
 #include "gtdynamics/utils/utils.h"
 #include "gtdynamics/utils/values.h"
@@ -231,26 +231,26 @@ gtsam::NonlinearFactorGraph ScrewJointBase::jointLimitFactors(
   gtsam::NonlinearFactorGraph graph;
   auto id = this->id();
   // Add joint angle limit factor.
-  graph.emplace_shared<JointLimitFactor>(
+  graph.emplace_shared<JointLimitDoubleFactor>(
       internal::JointAngleKey(id, t), opt.jl_cost_model,
       parameters().scalar_limits.value_lower_limit,
       parameters().scalar_limits.value_upper_limit,
       parameters().scalar_limits.value_limit_threshold);
 
   // Add joint velocity limit factors.
-  graph.emplace_shared<JointLimitFactor>(
+  graph.emplace_shared<JointLimitDoubleFactor>(
       internal::JointVelKey(id, t), opt.jl_cost_model,
       -parameters().velocity_limit, parameters().velocity_limit,
       parameters().velocity_limit_threshold);
 
   // Add joint acceleration limit factors.
-  graph.emplace_shared<JointLimitFactor>(
+  graph.emplace_shared<JointLimitDoubleFactor>(
       internal::JointAccelKey(id, t), opt.jl_cost_model,
       -parameters().acceleration_limit, parameters().acceleration_limit,
       parameters().acceleration_limit_threshold);
 
   // Add joint torque limit factors.
-  graph.emplace_shared<JointLimitFactor>(
+  graph.emplace_shared<JointLimitDoubleFactor>(
       internal::TorqueKey(id, t), opt.jl_cost_model, -parameters().torque_limit,
       parameters().torque_limit, parameters().torque_limit_threshold);
   return graph;

--- a/gtdynamics/universal_robot/ScrewJointBase.h
+++ b/gtdynamics/universal_robot/ScrewJointBase.h
@@ -122,13 +122,6 @@ class ScrewJointBase : public JointTyped {
       const LinkSharedPtr &link, boost::optional<Vector6> wrench = boost::none,
       gtsam::OptionalJacobian<1, 6> H_wrench = boost::none) const override;
 
-  // TODO(frank): document and possibly eliminate
-  gtsam::Matrix6 AdjointMapJacobianJointAngle(const LinkSharedPtr &link,
-                                              double q) const override {
-    return AdjointMapJacobianQ(q, relativePoseOf(otherLink(link), 0),
-                               screwAxis(link));
-  }
-
   /// Return forward dynamics priors on torque.
   gtsam::GaussianFactorGraph linearFDPriors(
       size_t t, const gtsam::Values &known_values,

--- a/gtdynamics/universal_robot/ScrewJointBase.h
+++ b/gtdynamics/universal_robot/ScrewJointBase.h
@@ -119,7 +119,7 @@ class ScrewJointBase : public JointTyped {
       gtsam::OptionalJacobian<6, 6> H_other_twist_accel =
           boost::none) const override;
 
-  JointTorque transformWrenchToTorqueTyped(
+  JointTorque transformWrenchToTorque(
       const LinkSharedPtr &link, boost::optional<Vector6> wrench = boost::none,
       gtsam::OptionalJacobian<1, 6> H_wrench = boost::none) const override;
 

--- a/gtdynamics/universal_robot/ScrewJointBase.h
+++ b/gtdynamics/universal_robot/ScrewJointBase.h
@@ -119,7 +119,7 @@ class ScrewJointBase : public JointTyped {
       gtsam::OptionalJacobian<6, 6> H_other_twist_accel =
           boost::none) const override;
 
-  JointTorque transformWrenchToTorque(
+  JointTorque transformWrenchToTorqueTyped(
       const LinkSharedPtr &link, boost::optional<Vector6> wrench = boost::none,
       gtsam::OptionalJacobian<1, 6> H_wrench = boost::none) const override;
 

--- a/gtdynamics/universal_robot/ScrewJointBase.h
+++ b/gtdynamics/universal_robot/ScrewJointBase.h
@@ -26,7 +26,6 @@
 #include <map>
 #include <string>
 
-#include "gtdynamics/factors/JointLimitFactor.h"
 #include "gtdynamics/universal_robot/JointTyped.h"
 #include "gtdynamics/utils/utils.h"
 #include "gtdynamics/utils/values.h"

--- a/gtdynamics/utils/utils.cpp
+++ b/gtdynamics/utils/utils.cpp
@@ -33,27 +33,6 @@ gtsam::Vector radians(const gtsam::Vector &degree) {
   return radian;
 }
 
-gtsam::Matrix6 AdjointMapJacobianQ(double q, const gtsam::Pose3 &jMi,
-                                   const gtsam::Vector6 &screw_axis) {
-  // taking opposite value of screw_axis_ is because
-  // jTi = Pose3::Expmap(-screw_axis_ * q) * jMi;
-  gtsam::Vector3 w = -screw_axis.head<3>();
-  gtsam::Vector3 v = -screw_axis.tail<3>();
-  gtsam::Pose3 kTj = gtsam::Pose3::Expmap(-screw_axis * q) * jMi;
-  auto w_skew = gtsam::skewSymmetric(w);
-  gtsam::Matrix3 H_expo = w_skew * cosf(q) + w_skew * w_skew * sinf(q);
-  gtsam::Matrix3 H_R = H_expo * jMi.rotation().matrix();
-  gtsam::Vector3 H_T =
-      H_expo * (jMi.translation() - w_skew * v) + w * w.transpose() * v;
-  gtsam::Matrix3 H_TR = gtsam::skewSymmetric(H_T) * kTj.rotation().matrix() +
-                        gtsam::skewSymmetric(kTj.translation()) * H_R;
-  gtsam::Matrix6 H = gtsam::Z_6x6;
-  gtsam::insertSub(H, H_R, 0, 0);
-  gtsam::insertSub(H, H_TR, 3, 0);
-  gtsam::insertSub(H, H_R, 3, 3);
-  return H;
-}
-
 gtsam::Matrix getQc(const gtsam::SharedNoiseModel Qc_model) {
   gtsam::noiseModel::Gaussian *Gassian_model =
       dynamic_cast<gtsam::noiseModel::Gaussian *>(Qc_model.get());

--- a/gtdynamics/utils/utils.h
+++ b/gtdynamics/utils/utils.h
@@ -44,15 +44,6 @@ double radians(double degree);
 gtsam::Vector radians(const gtsam::Vector &degree);
 
 /**
- * Calculate AdjointMap jacobian w.r.t. joint coordinate q
- * @param q joint angle
- * @param jMi this COM frame, expressed in next link's COM frame at rest
- * @param screw_axis screw axis expressed in kth link's COM frame
- */
-gtsam::Matrix6 AdjointMapJacobianQ(double q, const gtsam::Pose3 &jMi,
-                                   const gtsam::Vector6 &screw_axis);
-
-/**
  * Calculate Gaussian Process system transition matrix
  * @param tau timestep
  */

--- a/tests/testTorqueFactor.cpp
+++ b/tests/testTorqueFactor.cpp
@@ -53,14 +53,14 @@ TEST(TorqueFactor, error) {
   // Check evaluateError.
   double torque = 20;
   gtsam::Vector wrench = (gtsam::Vector(6) << 0, 0, 10, 0, 10, 0).finished();
-  gtsam::Vector1 actual_errors = factor.evaluateError(wrench, torque);
+  gtsam::Values values;
+  InsertWrench(&values, joint->child()->id(), joint->id(), 777, wrench);
+  InsertTorque(&values, joint->id(), 777, torque);
+  gtsam::Vector1 actual_errors = factor.unwhitenedError(values);
   gtsam::Vector1 expected_errors(0);
   EXPECT(assert_equal(expected_errors, actual_errors, 1e-6));
 
   // Make sure linearization is correct.
-  gtsam::Values values;
-  values.insert(wrench_key, wrench);
-  values.insert(torque_key, torque);
   double diffDelta = 1e-7;
   EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, diffDelta, 1e-7);
 }

--- a/tests/testTwistAccelFactor.cpp
+++ b/tests/testTwistAccelFactor.cpp
@@ -48,7 +48,7 @@ TEST(TwistAccelFactor, error) {
   auto joint = make_joint(cMp, screw_axis);
 
   // create factor
-  TwistAccelFactor factor(example::cost_model, joint, 0);
+  TwistAccelFactor factor(example::cost_model, joint, 777);
 
   double q = M_PI / 4, qVel = 10, qAccel = 10;
   gtsam::Vector twist, twistAccel_p, twistAccel_c;
@@ -57,12 +57,12 @@ TEST(TwistAccelFactor, error) {
   twistAccel_c =
       (gtsam::Vector(6) << 0, 0, 20, 7.07106781, 27.0710678, 0).finished();
   gtsam::Values values;
-  InsertJointAngle(&values, joint->id(), q);
-  InsertJointVel(&values, joint->id(), qVel);
-  InsertJointAccel(&values, joint->id(), qAccel);
-  InsertTwist(&values, joint->child()->id(), twist);
-  InsertTwistAccel(&values, joint->parent()->id(), twistAccel_p);
-  InsertTwistAccel(&values, joint->child()->id(), twistAccel_c);
+  InsertJointAngle(&values, joint->id(), 777, q);
+  InsertJointVel(&values, joint->id(), 777, qVel);
+  InsertJointAccel(&values, joint->id(), 777, qAccel);
+  InsertTwist(&values, joint->child()->id(), 777, twist);
+  InsertTwistAccel(&values, joint->parent()->id(), 777, twistAccel_p);
+  InsertTwistAccel(&values, joint->child()->id(), 777, twistAccel_c);
 
   gtsam::Vector6 actual_errors, expected_errors;
   actual_errors = factor.unwhitenedError(values);
@@ -82,19 +82,19 @@ TEST(TwistAccelFactor, error_1) {
 
   auto joint = make_joint(cMp, screw_axis);
 
-  TwistAccelFactor factor(example::cost_model, joint, 0);
+  TwistAccelFactor factor(example::cost_model, joint, 777);
   double q = 0, qVel = 0, qAccel = -9.8;
   gtsam::Vector6 twist, twistAccel_p, twistAccel_c;
   twist = (gtsam::Vector(6) << 0, 0, 0, 0, 0, 0).finished();
   twistAccel_p = (gtsam::Vector(6) << 0, 0, 0, 0, 9.8, 0).finished();
   twistAccel_c = (gtsam::Vector(6) << 0, 0, -9.8, 0, 0, 0).finished();
   gtsam::Values values;
-  InsertJointAngle(&values, joint->id(), q);
-  InsertJointVel(&values, joint->id(), qVel);
-  InsertJointAccel(&values, joint->id(), qAccel);
-  InsertTwist(&values, joint->child()->id(), twist);
-  InsertTwistAccel(&values, joint->parent()->id(), twistAccel_p);
-  InsertTwistAccel(&values, joint->child()->id(), twistAccel_c);
+  InsertJointAngle(&values, joint->id(), 777, q);
+  InsertJointVel(&values, joint->id(), 777, qVel);
+  InsertJointAccel(&values, joint->id(), 777, qAccel);
+  InsertTwist(&values, joint->child()->id(), 777, twist);
+  InsertTwistAccel(&values, joint->parent()->id(), 777, twistAccel_p);
+  InsertTwistAccel(&values, joint->child()->id(), 777, twistAccel_c);
 
   gtsam::Vector6 actual_errors, expected_errors;
   actual_errors = factor.unwhitenedError(values);

--- a/tests/testTwistFactor.cpp
+++ b/tests/testTwistFactor.cpp
@@ -45,7 +45,7 @@ TEST(TwistFactor, error) {
 
   auto joint = make_joint(cMp, screw_axis);
 
-  TwistFactor factor(example::cost_model, joint, 0);
+  TwistFactor factor(example::cost_model, joint, 777);
 
   double q = M_PI / 4, qVel = 10;
   gtsam::Vector twist_p, twist_c;
@@ -53,10 +53,10 @@ TEST(TwistFactor, error) {
   twist_c =
       (gtsam::Vector(6) << 0, 0, 20, 7.07106781, 27.0710678, 0).finished();
   gtsam::Values values;
-  InsertJointAngle(&values, joint->id(), q);
-  InsertJointVel(&values, joint->id(), qVel);
-  InsertTwist(&values, joint->parent()->id(), twist_p);
-  InsertTwist(&values, joint->child()->id(), twist_c);
+  InsertJointAngle(&values, joint->id(), 777, q);
+  InsertJointVel(&values, joint->id(), 777, qVel);
+  InsertTwist(&values, joint->parent()->id(), 777, twist_p);
+  InsertTwist(&values, joint->child()->id(), 777, twist_c);
 
   gtsam::Vector6 actual_errors, expected_errors;
   actual_errors = factor.unwhitenedError(values);


### PR DESCRIPTION
Previously, many factors and other places in the code were depending on JointTyped which I think was not appropriate.  I refactored these to be agnostic to joint type as an intermediate step to adding Spherical/Ball and Universal joints.  I believe the code is now much cleaner and less hacky.

For example, `TwistFactor` was previously using `JointTyped` and calling the `JointTyped` version of `transformTwistTo`.  The problem with this is that then any instance of `TwistFactor` has to be templated / type known at compile-time.  However, the type kind of has to be determined at run-time, e.g. reading from an SDF you couldn't possibly know the types before runtime.  Now, `TwistFactor` calls the `Joint` version of `transformTwistTo` (argument `const Values &q_and_q_dot`).

## Tradeoffs
The upside is that this makes the code much more general and easier to maintain (IMO) and will make adding Spherical/Ball/other joints much easier.
The downside is a potential runtime penalty due to runtime polymorphism (not benchmarked, but I would guess negligible).

## Alternatives
An alternative would be to shift all the runtime polymorphism to the graph generation (e.g. DynamicsGraph, aFactors, vFactors, etc) but I believe this makes the code much more difficult to maintain since we would have tons of RTTI, e.g.
```c++
if (auto *joint_cast = dynamic_pointer_cast<ScrewJointBase>(joint)) {
  graph.emplace_shared<TwistFactor<ScrewJointBase>>(args);
} else if ... // for every joint type, and for every factor type
```
Alternatively, the factor creation functions could also be moved back into the Joint classes, but I think previously Frank strongly pushed for moving the factor creation functions out since the Link and Joint classes should be purely for defining the robot configuration and not have anything to do with factor graphs / gtsam.

## Notes/dependencies
https://github.com/borglab/gtsam/pull/885 (Adjoint with Jacobian) needs to be merged in first.
After https://github.com/borglab/gtsam/pull/884 merges, we can also optionally clean up some code (I left comments about "Due to quirks of OptionalJacobian, this is the cleanest way (Gerry)" prior to having created that PR, but with the PR then I think it can be cleaner), but that's low priority.

## API / Breaking Changes
* A few factors previously took the raw keys as arguments.  I changed it to just taking in the timestamp instead, since they were already taking in the joint and the keys can be obtained from the joints + time.  Applies to both c++ and python
* Changed a lot of `JointTyped` arguments to just `Joint` arguments which lets us remove all the ugly `boost::static_pointer_cast<const JointTyped>` casts
* Renamed `JointLimitFactor` to `JointLimitDoubleFactor` since it really is specific to just double-type joints and we will have to be adding new JointLimitFactors for other Joint types soon
* Removed `AdjointMapJacobianQ` in favor of `pose.Adjoint(twist, H_pose, H_twist)` combined with `pose = joint->poseOf(link, pose_H_q)` and `H_q = H_pose * pose_H_q`.
* Added a virtual function `transformWrenchToTorqueVector` so that `TorqueFactor` could be made type-agnostic.  This now mirrors all the other functions e.g. `transformTwistTo` `transformTwistAccelTo` etc.
* Changed some `boost::optional<Matrix &>` to `OptionalJacobian<-1, -1>`

All unit tests still passing of course, so if anyone has objections, add unit tests :)