### PR TITLE
Remove extraneous DEBUG flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,7 @@ set(GTSAM_LIBS gtsam)
 
 find_package(GTSAMCMakeTools)
 include(GtsamMakeConfigFile)
-
-option(GTDYNAMICS_BUILD_WITH_MARCH_NATIVE  "Enable/Disable building with all instructions supported by native architecture (binary may not be portable!)" ON)
-set(GTSAM_BUILD_WITH_MARCH_NATIVE ${GTDYNAMICS_BUILD_WITH_MARCH_NATIVE})
 include(GtsamBuildTypes)
-
 include(GtsamTesting)
 
 # For unit tests and scripts.
@@ -91,7 +87,7 @@ message(STATUS "Build Python                                : ${GTDYNAMICS_BUILD
 if(GTDYNAMICS_BUILD_PYTHON)
   message(STATUS "Python Version                              : ${WRAP_PYTHON_VERSION}")
 endif()
-message(STATUS "Build march=native                          : ${GTDYNAMICS_BUILD_WITH_MARCH_NATIVE}")
+message(STATUS "Build march=native                          : ${GTSAM_BUILD_WITH_MARCH_NATIVE}")
 message(STATUS "Build Scripts                               : ${GTDYNAMICS_BUILD_SCRIPTS}")
 message(STATUS "Build Examples                              : ${GTDYNAMICS_BUILD_EXAMPLES}")
 message(STATUS "===============================================================")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,11 @@ set(GTSAM_LIBS gtsam)
 
 find_package(GTSAMCMakeTools)
 include(GtsamMakeConfigFile)
+
+option(GTDYNAMICS_BUILD_WITH_MARCH_NATIVE  "Enable/Disable building with all instructions supported by native architecture (binary may not be portable!)" ON)
+set(GTSAM_BUILD_WITH_MARCH_NATIVE ${GTDYNAMICS_BUILD_WITH_MARCH_NATIVE})
 include(GtsamBuildTypes)
+
 include(GtsamTesting)
 
 # For unit tests and scripts.
@@ -87,6 +91,7 @@ message(STATUS "Build Python                                : ${GTDYNAMICS_BUILD
 if(GTDYNAMICS_BUILD_PYTHON)
   message(STATUS "Python Version                              : ${WRAP_PYTHON_VERSION}")
 endif()
+message(STATUS "Build march=native                          : ${GTDYNAMICS_BUILD_WITH_MARCH_NATIVE}")
 message(STATUS "Build Scripts                               : ${GTDYNAMICS_BUILD_SCRIPTS}")
 message(STATUS "Build Examples                              : ${GTDYNAMICS_BUILD_EXAMPLES}")
 message(STATUS "===============================================================")

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,10 +1,2 @@
 gtsamAddExamplesGlob("*.cpp" "" "gtdynamics")
 
-option(DEBUG "Turn on debug mode to print out more info?" OFF)
-
-if(DEBUG)
-    add_definitions(-DDEBUG=1)
-else()
-    add_definitions(-DDEBUG=0)
-endif()
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,1 @@
 gtsamAddTestsGlob(tests "test*.cpp" "" "gtdynamics")
-
-option(DEBUG "Turn on debug mode to print out more info?" OFF)
-
-if(DEBUG)
-    add_definitions(-DDEBUG=1)
-else()
-    add_definitions(-DDEBUG=0)
-endif()


### PR DESCRIPTION
~~GTDynamics doesn't compile on M1 Macs when GTSAM's `march=native` flag is set and it inherits this value. Even if GTSAM explicitly doesn't have `march=native` set, the way the CMake is setup means that this flag will be set when the GTSAM cmake files are included within GTDynamics.~~

~~To allow one to set the flag off, this PR introduces a new flag for GTDynamics.~~

PR to remove some extra DEBUG flags which aren't necessary.