### PR TITLE
Convert Optimizer Arguments from shared pointers to objects

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -329,8 +329,8 @@ class KinematicsParameters : gtdynamics::OptimizationParameters {
 };
 
 class Kinematics {
-  Kinematics(gtdynamics::KinematicsParameters *parameters =
-                 boost::make_shared<const gtdynamics::KinematicsParameters>());
+  Kinematics(gtdynamics::KinematicsParameters parameters =
+                 gtdynamics::KinematicsParameters());
   gtsam::Values inverse(const gtdynamics::Slice &slice,
                         const gtdynamics::Robot &robot,
                         const gtdynamics::ContactGoals &contact_goals);

--- a/gtdynamics/kinematics/Kinematics.h
+++ b/gtdynamics/kinematics/Kinematics.h
@@ -15,8 +15,8 @@
 
 #include <gtdynamics/optimizer/Optimizer.h>
 #include <gtdynamics/universal_robot/Robot.h>
-#include <gtdynamics/utils/PointOnLink.h>
 #include <gtdynamics/utils/Interval.h>
+#include <gtdynamics/utils/PointOnLink.h>
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/LevenbergMarquardtParams.h>
@@ -82,14 +82,13 @@ struct KinematicsParameters : public OptimizationParameters {
 /// All things kinematics, zero velocities/twists, and no forces.
 class Kinematics : public Optimizer {
  protected:
-  boost::shared_ptr<const KinematicsParameters> p_;  // overrides Base::p_
+  const KinematicsParameters p_;  // overrides Base::p_
 
  public:
   /**
    * @fn Constructor.
    */
-  Kinematics(const boost::shared_ptr<const KinematicsParameters>& parameters =
-                 boost::make_shared<const KinematicsParameters>())
+  Kinematics(const KinematicsParameters& parameters = KinematicsParameters())
       : Optimizer(parameters), p_(parameters) {}
 
   /**

--- a/gtdynamics/kinematics/KinematicsSlice.cpp
+++ b/gtdynamics/kinematics/KinematicsSlice.cpp
@@ -42,10 +42,10 @@ NonlinearFactorGraph Kinematics::graph<Slice>(const Slice& slice,
   // Constrain kinematics at joints.
   for (auto&& joint : robot.joints()) {
     const auto j = joint->id();
-    graph.add(PoseFactor(
-        internal::PoseKey(joint->parent()->id(), slice.k),
-        internal::PoseKey(joint->child()->id(), slice.k),
-        internal::JointAngleKey(j, slice.k), p_->p_cost_model, joint));
+    graph.add(PoseFactor(internal::PoseKey(joint->parent()->id(), slice.k),
+                         internal::PoseKey(joint->child()->id(), slice.k),
+                         internal::JointAngleKey(j, slice.k), p_.p_cost_model,
+                         joint));
   }
 
   return graph;
@@ -53,11 +53,11 @@ NonlinearFactorGraph Kinematics::graph<Slice>(const Slice& slice,
 
 template <>
 EqualityConstraints Kinematics::constraints<Slice>(const Slice& slice,
-                                              const Robot& robot) const {
+                                                   const Robot& robot) const {
   EqualityConstraints constraints;
 
   // Constrain kinematics at joints.
-  gtsam::Vector6 tolerance = p_->p_cost_model->sigmas();
+  gtsam::Vector6 tolerance = p_.p_cost_model->sigmas();
   for (auto&& joint : robot.joints()) {
     auto constraint_expr = joint->poseConstraint(slice.k);
     constraints.emplace_shared<VectorExpressionEquality<6>>(constraint_expr,
@@ -67,7 +67,6 @@ EqualityConstraints Kinematics::constraints<Slice>(const Slice& slice,
   return constraints;
 }
 
-
 template <>
 NonlinearFactorGraph Kinematics::pointGoalObjectives<Slice>(
     const Slice& slice, const ContactGoals& contact_goals) const {
@@ -76,7 +75,7 @@ NonlinearFactorGraph Kinematics::pointGoalObjectives<Slice>(
   // Add objectives.
   for (const ContactGoal& goal : contact_goals) {
     const gtsam::Key pose_key = internal::PoseKey(goal.link()->id(), slice.k);
-    graph.emplace_shared<PointGoalFactor>(pose_key, p_->g_cost_model,
+    graph.emplace_shared<PointGoalFactor>(pose_key, p_.g_cost_model,
                                           goal.contactInCoM(), goal.goal_point);
   }
 
@@ -89,7 +88,7 @@ EqualityConstraints Kinematics::pointGoalConstraints<Slice>(
   EqualityConstraints constraints;
 
   // Add objectives.
-  gtsam::Vector3 tolerance = p_->g_cost_model->sigmas();
+  gtsam::Vector3 tolerance = p_.g_cost_model->sigmas();
   for (const ContactGoal& goal : contact_goals) {
     const gtsam::Key pose_key = internal::PoseKey(goal.link()->id(), slice.k);
     auto constraint_expr =
@@ -108,7 +107,7 @@ NonlinearFactorGraph Kinematics::jointAngleObjectives<Slice>(
   // Minimize the joint angles.
   for (auto&& joint : robot.joints()) {
     const gtsam::Key key = internal::JointAngleKey(joint->id(), slice.k);
-    graph.addPrior<double>(key, 0.0, p_->prior_q_cost_model);
+    graph.addPrior<double>(key, 0.0, p_.prior_q_cost_model);
   }
 
   return graph;
@@ -141,7 +140,6 @@ template <>
 Values Kinematics::inverse<Slice>(const Slice& slice, const Robot& robot,
                                   const ContactGoals& contact_goals,
                                   bool contact_goals_as_constraints) const {
-
   // Robot kinematics constraints
   auto constraints = this->constraints(slice, robot);
   NonlinearFactorGraph graph;
@@ -149,8 +147,7 @@ Values Kinematics::inverse<Slice>(const Slice& slice, const Robot& robot,
   // Contact goals
   if (contact_goals_as_constraints) {
     constraints.add(this->pointGoalConstraints(slice, contact_goals));
-  }
-  else {
+  } else {
     graph.add(pointGoalObjectives(slice, contact_goals));
   }
 

--- a/gtdynamics/optimizer/AugmentedLagrangianOptimizer.cpp
+++ b/gtdynamics/optimizer/AugmentedLagrangianOptimizer.cpp
@@ -46,8 +46,7 @@ void update_parameters(const EqualityConstraints& constraints,
 
 gtsam::Values AugmentedLagrangianOptimizer::optimize(
     const gtsam::NonlinearFactorGraph& graph,
-    const EqualityConstraints& constraints,
-    const gtsam::Values& initial_values,
+    const EqualityConstraints& constraints, const gtsam::Values& initial_values,
     ConstrainedOptResult* intermediate_result) const {
   gtsam::Values values = initial_values;
 
@@ -60,7 +59,7 @@ gtsam::Values AugmentedLagrangianOptimizer::optimize(
 
   // Solve the constrained optimization problem by solving a sequence of
   // unconstrained optimization problems.
-  for (int i = 0; i < p_->num_iterations; i++) {
+  for (int i = 0; i < p_.num_iterations; i++) {
     // Construct merit function.
     gtsam::NonlinearFactorGraph merit_graph = graph;
 
@@ -74,7 +73,7 @@ gtsam::Values AugmentedLagrangianOptimizer::optimize(
 
     // Run LM optimization.
     gtsam::LevenbergMarquardtOptimizer optimizer(merit_graph, values,
-                                                 p_->lm_parameters);
+                                                 p_.lm_parameters);
     auto result = optimizer.optimize();
 
     // Update parameters.

--- a/gtdynamics/optimizer/AugmentedLagrangianOptimizer.h
+++ b/gtdynamics/optimizer/AugmentedLagrangianOptimizer.h
@@ -35,15 +35,14 @@ struct AugmentedLagrangianParameters
 /// Augmented Lagrangian method only considering equality constraints.
 class AugmentedLagrangianOptimizer : public ConstrainedOptimizer {
  protected:
-  boost::shared_ptr<const AugmentedLagrangianParameters> p_;
+  const AugmentedLagrangianParameters p_;
 
  public:
-  AugmentedLagrangianOptimizer()
-      : p_(boost::make_shared<const AugmentedLagrangianParameters>()) {}
+  /// Default constructor
+  AugmentedLagrangianOptimizer() : p_(AugmentedLagrangianParameters()) {}
 
-  /* Construct from parameters. */
-  AugmentedLagrangianOptimizer(
-      const boost::shared_ptr<const AugmentedLagrangianParameters>& parameters)
+  /// Construct from parameters.
+  AugmentedLagrangianOptimizer(const AugmentedLagrangianParameters& parameters)
       : p_(parameters) {}
 
   /// Run optimization.

--- a/gtdynamics/optimizer/Optimizer.cpp
+++ b/gtdynamics/optimizer/Optimizer.cpp
@@ -11,10 +11,10 @@
  * @author: Frank Dellaert
  */
 
-#include <gtdynamics/optimizer/Optimizer.h>
-#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
-#include <gtdynamics/optimizer/PenaltyMethodOptimizer.h>
 #include <gtdynamics/optimizer/AugmentedLagrangianOptimizer.h>
+#include <gtdynamics/optimizer/Optimizer.h>
+#include <gtdynamics/optimizer/PenaltyMethodOptimizer.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
 
 namespace gtdynamics {
 
@@ -24,33 +24,33 @@ using gtsam::Values;
 Values Optimizer::optimize(const NonlinearFactorGraph& graph,
                            const Values& initial_values) const {
   gtsam::LevenbergMarquardtOptimizer optimizer(graph, initial_values,
-                                               p_->lm_parameters);
+                                               p_.lm_parameters);
   const Values result = optimizer.optimize();
   return result;
 }
 
 Values Optimizer::optimize(const gtsam::NonlinearFactorGraph& graph,
-                        const EqualityConstraints& constraints,
-                        const gtsam::Values& initial_values) const {
-
-  if (p_->method == OptimizationParameters::Method::SOFT_CONSTRAINTS) {
+                           const EqualityConstraints& constraints,
+                           const gtsam::Values& initial_values) const {
+  if (p_.method == OptimizationParameters::Method::SOFT_CONSTRAINTS) {
     auto merit_graph = graph;
-    for (const auto& constraint: constraints) {
+    for (const auto& constraint : constraints) {
       merit_graph.add(constraint->createFactor(1.0));
     }
     return optimize(merit_graph, initial_values);
-  }
-  else if (p_->method == OptimizationParameters::Method::PENALTY) {
-    auto params = boost::make_shared<PenaltyMethodParameters>(p_->lm_parameters);
+
+  } else if (p_.method == OptimizationParameters::Method::PENALTY) {
+    PenaltyMethodParameters params = p_.lm_parameters;
     PenaltyMethodOptimizer optimizer(params);
     return optimizer.optimize(graph, constraints, initial_values);
-  }
-  else if (p_->method == OptimizationParameters::Method::AUGMENTED_LAGRANGIAN) {
-    auto params = boost::make_shared<AugmentedLagrangianParameters>(p_->lm_parameters);
+
+  } else if (p_.method ==
+             OptimizationParameters::Method::AUGMENTED_LAGRANGIAN) {
+    AugmentedLagrangianParameters params = p_.lm_parameters;
     AugmentedLagrangianOptimizer optimizer(params);
     return optimizer.optimize(graph, constraints, initial_values);
-  }
-  else {
+
+  } else {
     throw std::runtime_error("optimization method not recognized.");
   }
 }

--- a/gtdynamics/optimizer/Optimizer.h
+++ b/gtdynamics/optimizer/Optimizer.h
@@ -27,13 +27,9 @@ namespace gtdynamics {
 
 /// Optimization parameters shared between all solvers
 struct OptimizationParameters {
-  enum Method {
-    SOFT_CONSTRAINTS = 0,
-    PENALTY = 1,
-    AUGMENTED_LAGRANGIAN = 2
-  };
+  enum Method { SOFT_CONSTRAINTS = 0, PENALTY = 1, AUGMENTED_LAGRANGIAN = 2 };
 
-  Method method = Method::SOFT_CONSTRAINTS; // optimization method
+  Method method = Method::SOFT_CONSTRAINTS;       // optimization method
   gtsam::LevenbergMarquardtParams lm_parameters;  // LM parameters
   OptimizationParameters() {
     lm_parameters.setlambdaInitial(1e7);
@@ -44,13 +40,13 @@ struct OptimizationParameters {
 /// Base class for GTDynamics optimizer hierarchy.
 class Optimizer {
  protected:
-  boost::shared_ptr<const OptimizationParameters> p_;
+  const OptimizationParameters p_;
 
  public:
   /**
    * @fn Constructor.
    */
-  Optimizer(const boost::shared_ptr<const OptimizationParameters>& parameters)
+  Optimizer(const OptimizationParameters& parameters = OptimizationParameters())
       : p_(parameters) {}
 
   /**

--- a/gtdynamics/optimizer/PenaltyMethodOptimizer.cpp
+++ b/gtdynamics/optimizer/PenaltyMethodOptimizer.cpp
@@ -20,11 +20,11 @@ gtsam::Values PenaltyMethodOptimizer::optimize(
     const EqualityConstraints& constraints, const gtsam::Values& initial_values,
     ConstrainedOptResult* intermediate_result) const {
   gtsam::Values values = initial_values;
-  double mu = p_->initial_mu;
+  double mu = p_.initial_mu;
 
   // Solve the constrained optimization problem by solving a sequence of
   // unconstrained optimization problems.
-  for (int i = 0; i < p_->num_iterations; i++) {
+  for (int i = 0; i < p_.num_iterations; i++) {
     gtsam::NonlinearFactorGraph merit_graph = graph;
 
     // Create factors corresponding to penalty terms of constraints.
@@ -34,12 +34,12 @@ gtsam::Values PenaltyMethodOptimizer::optimize(
 
     // Run optimization.
     gtsam::LevenbergMarquardtOptimizer optimizer(merit_graph, values,
-                                                 p_->lm_parameters);
+                                                 p_.lm_parameters);
     auto result = optimizer.optimize();
 
     // Save results and update parameters.
     values = result;
-    mu *= p_->mu_increase_rate;
+    mu *= p_.mu_increase_rate;
 
     /// Store intermediate results.
     if (intermediate_result != nullptr) {

--- a/gtdynamics/optimizer/PenaltyMethodOptimizer.h
+++ b/gtdynamics/optimizer/PenaltyMethodOptimizer.h
@@ -21,7 +21,7 @@ namespace gtdynamics {
 struct PenaltyMethodParameters : public ConstrainedOptimizationParameters {
   using Base = ConstrainedOptimizationParameters;
   size_t num_iterations;
-  double initial_mu;  // initial penalty parameter
+  double initial_mu;        // initial penalty parameter
   double mu_increase_rate;  // increase rate of penalty parameter
 
   /** Constructor. */
@@ -44,18 +44,16 @@ struct PenaltyMethodParameters : public ConstrainedOptimizationParameters {
 /// Penalty method only considering equality constraints.
 class PenaltyMethodOptimizer : public ConstrainedOptimizer {
  protected:
-  boost::shared_ptr<const PenaltyMethodParameters> p_;
+  const PenaltyMethodParameters p_;
 
  public:
   /** Default constructor. */
-  PenaltyMethodOptimizer()
-      : p_(boost::make_shared<const PenaltyMethodParameters>()) {}
+  PenaltyMethodOptimizer() : p_(PenaltyMethodParameters()) {}
 
   /**
    * Construct from parameters.
    */
-  PenaltyMethodOptimizer(
-      const boost::shared_ptr<const PenaltyMethodParameters>& parameters)
+  PenaltyMethodOptimizer(const PenaltyMethodParameters& parameters)
       : p_(parameters) {}
 
   /// Run optimization.

--- a/gtdynamics/statics/Statics.h
+++ b/gtdynamics/statics/Statics.h
@@ -82,13 +82,13 @@ struct StaticsParameters : public KinematicsParameters {
 /// Algorithms for Statics, i.e. kinematics + wrenches at rest
 class Statics : public Kinematics {
  protected:
-  boost::shared_ptr<const StaticsParameters> p_;  // overrides Base::p_
+  const StaticsParameters p_;  // overrides Base::p_
 
  public:
   /**
    * @fn Constructor.
    */
-  Statics(const boost::shared_ptr<const StaticsParameters>& parameters)
+  Statics(const StaticsParameters& parameters = StaticsParameters())
       : Kinematics(parameters), p_(parameters) {}
 
   /// Graph with a WrenchEquivalenceFactor for each joint

--- a/gtdynamics/statics/StaticsSlice.cpp
+++ b/gtdynamics/statics/StaticsSlice.cpp
@@ -33,8 +33,7 @@ gtsam::NonlinearFactorGraph Statics::wrenchEquivalenceFactors(
     const Slice& slice, const Robot& robot) const {
   gtsam::NonlinearFactorGraph graph;
   for (auto&& joint : robot.joints()) {
-    graph.add(WrenchEquivalenceFactor(p_->f_cost_model, joint,
-                                                  slice.k));
+    graph.add(WrenchEquivalenceFactor(p_.f_cost_model, joint, slice.k));
   }
   return graph;
 }
@@ -43,7 +42,7 @@ gtsam::NonlinearFactorGraph Statics::torqueFactors(const Slice& slice,
                                                    const Robot& robot) const {
   gtsam::NonlinearFactorGraph graph;
   for (auto&& joint : robot.joints()) {
-    graph.add(TorqueFactor(p_->t_cost_model, joint, slice.k));
+    graph.add(TorqueFactor(p_.t_cost_model, joint, slice.k));
   }
   return graph;
 }
@@ -51,10 +50,10 @@ gtsam::NonlinearFactorGraph Statics::torqueFactors(const Slice& slice,
 gtsam::NonlinearFactorGraph Statics::wrenchPlanarFactors(
     const Slice& slice, const Robot& robot) const {
   gtsam::NonlinearFactorGraph graph;
-  if (p_->planar_axis)
+  if (p_.planar_axis)
     for (auto&& joint : robot.joints()) {
-      graph.add(WrenchPlanarFactor(p_->planar_cost_model, *p_->planar_axis,
-                                   joint, slice.k));
+      graph.add(WrenchPlanarFactor(p_.planar_cost_model, *p_.planar_axis, joint,
+                                   slice.k));
     }
   return graph;
 }
@@ -77,8 +76,8 @@ gtsam::NonlinearFactorGraph Statics::graph(const Slice& slice,
 
     // Add static wrench factor for link.
     graph.emplace_shared<StaticWrenchFactor>(
-        wrench_keys, internal::PoseKey(link->id(), k), p_->fs_cost_model,
-        link->mass(), p_->gravity);
+        wrench_keys, internal::PoseKey(link->id(), k), p_.fs_cost_model,
+        link->mass(), p_.gravity);
   }
 
   /// Add a WrenchEquivalenceFactor for each joint.
@@ -149,8 +148,7 @@ gtsam::Values Statics::minimizeTorques(const Slice& slice,
   values.insert(initialValues(slice, robot));
 
   // TODO(frank): make IPOPT optimizer base class.
-  gtsam::LevenbergMarquardtOptimizer optimizer(graph, values,
-                                               p_->lm_parameters);
+  gtsam::LevenbergMarquardtOptimizer optimizer(graph, values, p_.lm_parameters);
   return optimizer.optimize();
 }
 }  // namespace gtdynamics

--- a/tests/testKinematicsInterval.cpp
+++ b/tests/testKinematicsInterval.cpp
@@ -36,8 +36,8 @@ TEST(Interval, InverseKinematics) {
   const Interval interval(0, num_time_steps - 1);
 
   // Instantiate kinematics algorithms
-  auto parameters = boost::make_shared<KinematicsParameters>();
-  parameters->method = OptimizationParameters::Method::AUGMENTED_LAGRANGIAN;
+  KinematicsParameters parameters;
+  parameters.method = OptimizationParameters::Method::AUGMENTED_LAGRANGIAN;
   Kinematics kinematics(parameters);
 
   auto graph = kinematics.graph(interval, robot);
@@ -69,8 +69,8 @@ TEST(Interval, Interpolate) {
   contact_goals2[2] = {{RF, contact_in_com}, {0.4, -0.16, -0.2}};
 
   // Create expected values for start and end times
-  auto parameters = boost::make_shared<KinematicsParameters>();
-  parameters->method = OptimizationParameters::Method::SOFT_CONSTRAINTS;
+  KinematicsParameters parameters;
+  parameters.method = OptimizationParameters::Method::SOFT_CONSTRAINTS;
   Kinematics kinematics(parameters);
   auto result1 = kinematics.inverse(Slice(5), robot, contact_goals);
   auto result2 = kinematics.inverse(Slice(9), robot, contact_goals);

--- a/tests/testKinematicsSlice.cpp
+++ b/tests/testKinematicsSlice.cpp
@@ -32,8 +32,8 @@ TEST(Slice, InverseKinematics) {
   const Slice slice(k);
 
   // Instantiate kinematics algorithms
-  auto parameters = boost::make_shared<KinematicsParameters>();
-  parameters->method = OptimizationParameters::Method::AUGMENTED_LAGRANGIAN;
+  KinematicsParameters parameters;
+  parameters.method = OptimizationParameters::Method::AUGMENTED_LAGRANGIAN;
   Kinematics kinematics(parameters);
 
   // Create initial values

--- a/tests/testStaticsSlice.cpp
+++ b/tests/testStaticsSlice.cpp
@@ -70,8 +70,7 @@ TEST(Statics, OneMovingLink) {
   EXPECT_DOUBLES_EQUAL(expected_tau, tau, kTol);
 
   // Now do statics using GTD.
-  auto parameters2D =
-      boost::make_shared<StaticsParameters>(kSigmaDynamics, gravity2D);
+  StaticsParameters parameters2D(kSigmaDynamics, gravity2D);
   Statics statics(parameters2D);
   const size_t k = 777;
   const Slice slice(k);
@@ -105,8 +104,7 @@ TEST(Statics, Quadruped) {
 
   // Instantiate statics algorithms
   const Vector3 kGravity(0, 0, -10);
-  auto parameters3D =
-      boost::make_shared<StaticsParameters>(kSigmaDynamics, kGravity);
+  StaticsParameters parameters3D(kSigmaDynamics, kGravity);
   Statics statics(parameters3D);
 
   // Get an inverse kinematics solution


### PR DESCRIPTION
This fixes #320

This PR proposes to swap `Optimizer(const boost::shared_ptr<const OptimizerParams>& params)` with the simpler `Optimizer(const OptimizerParams& params)`. Currently we make use of shared pointers for optimizer parameters which seems unnecessarily verbose since we don't expect to have more than a handful of optimizers running. By using const references, we avoid the need to call `make_shared` at various places and improve the overall readability of the code.

Other benefits include being able to get quick auto-complete with the dot notation, simpler wrapping, and one less dependency on Boost.