### PR TITLE
Speedup Linux CI

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Configure
         run: |
-          cmake -DGTDYNAMICS_BUILD_PYTHON=OFF -DGTDYNAMICS_BUILD_CABLE_ROBOT=ON -DGTDYNAMICS_BUILD_JUMPING_ROBOT=ON ..
+          cmake -DGTDYNAMICS_BUILD_PYTHON=OFF -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF ..
         working-directory: ./build
 
       - name: Build

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -54,15 +54,17 @@ jobs:
 
           sudo apt-get -y install libtbb-dev libboost-all-dev libsdformat10-dev
 
+          # Install CppUnitLite.
+          git clone https://github.com/borglab/CppUnitLite.git
+          cd CppUnitLite && mkdir build && cd $_
+          cmake .. && sudo make -j4 install
+          cd ../../
+
       - name: GTSAM
         run: |
-          git clone https://github.com/borglab/gtsam.git
-          cd gtsam
-          mkdir build && cd build
-          cmake -D GTSAM_BUILD_EXAMPLES_ALWAYS=OFF -DGTSAM_WITH_TBB=OFF ..
-          sudo make -j$(nproc) install
-          sudo ldconfig
-          cd ../../ # go back to home directory
+          sudo add-apt-repository -y ppa:borglab/gtsam-develop
+          sudo apt-get -y update
+          sudo apt-get -y install libgtsam-no-tbb-dev libgtsam-no-tbb-unstable-dev
 
       - name: Checkout
         uses: actions/checkout@master


### PR DESCRIPTION
This PR goes towards #276 for the Linux CI. We should consider other options (such as docker containers) as well.

The CI speedup is 2x.