### PR TITLE
include(GNUInstallDirs)

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -86,5 +86,5 @@ jobs:
         working-directory: ./build
       
       - name: Install
-        run: make -j$(nproc) install
+        run: sudo make -j$(nproc) install
         working-directory: ./build

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -85,6 +85,6 @@ jobs:
         run: make -j$(nproc) check
         working-directory: ./build
       
-      -name: Install
+      - name: Install
         run: make -j$(nproc) install
         working-directory: ./build

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -84,3 +84,7 @@ jobs:
       - name: Test
         run: make -j$(nproc) check
         working-directory: ./build
+      
+      -name: Install
+        run: make -j$(nproc) install
+        working-directory: ./build

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -73,3 +73,7 @@ jobs:
       - name: Test
         run: make -j$(sysctl -n hw.physicalcpu) check
         working-directory: ./build
+
+      - name: Install
+        run: make -j$(sysctl -n hw.physicalcpu) install
+        working-directory: ./build

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -133,5 +133,5 @@ jobs:
         working-directory: ./build
 
       - name: Install
-        run: make -j4 python-install
+        run: sudo make -j4 python-install
         working-directory: ./build

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -135,4 +135,3 @@ jobs:
       - name: Install
         run: make -j4 python-install
         working-directory: ./build
-  

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -131,3 +131,8 @@ jobs:
       - name: Test
         run: make -j4 python-test
         working-directory: ./build
+
+      - name: Install
+        run: make -j4 python-install
+        working-directory: ./build
+  

--- a/gtdynamics/CMakeLists.txt
+++ b/gtdynamics/CMakeLists.txt
@@ -32,6 +32,7 @@ link_directories(${SDFormat_LIBRARY_DIRS})
 file(GLOB headers "*.h")
 file(GLOB sources "*.cpp")
 
+include(GNUInstallDirs)
 foreach(SOURCE_SUBDIR ${SOURCE_SUBDIRS})
   file(GLOB GLOB_RESULT
        ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_SUBDIR}/*.cpp)


### PR DESCRIPTION
I encountered the same issue as #324, and it turned out `${CMAKE_INSTALL_INCLUDEDIR}` is empty during compilation.

By looking at [CMake documentation](https://cmake.org/cmake/help/latest/command/install.html), I discover that we forgot to include GNUInstallDirs. After adding the line `include(GNUInstallDirs)`, everything works fine.

I'd also suggest to add `make install` into out github workflow so that we can check if installation is successful.