### PR TITLE
CMake Packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,3 +96,42 @@ message(STATUS "  Cable Robot                               : ${GTDYNAMICS_BUILD
 message(STATUS "  Jumping Robot                             : ${GTDYNAMICS_BUILD_JUMPING_ROBOT}")
 message(STATUS "  Panda Robot                               : ${GTDYNAMICS_BUILD_PANDA_ROBOT}")
 message(STATUS "===============================================================")
+
+# Create the export .cmake file.
+# We should use `install(EXPORT) instead of export()` so it exports the install file.
+install(EXPORT "${PROJECT_NAME}-exports"
+  FILE gtdynamics-exports.cmake
+  DESTINATION lib/cmake/gtdynamics
+)
+
+include(CMakePackageConfigHelpers)
+
+# Set the variables to be used for the cmake config file.
+if(WIN32 AND NOT CYGWIN)
+  set(INSTALL_CMAKE_DIR CMake/${PROJECT_NAME})
+else()
+  set(INSTALL_CMAKE_DIR lib/cmake/${PROJECT_NAME})
+endif()
+
+# Configure the config file that is includes the exports
+configure_package_config_file(
+  ${CMAKE_SOURCE_DIR}/Config.cmake.in
+  "${CMAKE_BINARY_DIR}/gtdynamicsConfig.cmake"
+  INSTALL_DESTINATION "${INSTALL_CMAKE_DIR}"
+  INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+
+# Generate the config file.
+write_basic_package_version_file(
+  "${PROJECT_BINARY_DIR}/gtdynamicsConfigVersion.cmake"
+  VERSION ${gtdynamics_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+# Install the config files.
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/gtdynamicsConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/gtdynamicsConfigVersion.cmake
+  DESTINATION lib/cmake/gtdynamics)
+
+# Include CPack *after* all flags. Needed for packaging the project.
+include(CPack)

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+# Add SDFormat dependency so it is included along with gtdynamics
+find_dependency(sdformat@SDFormat_VERSION@ REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/gtdynamics-exports.cmake")

--- a/gtdynamics/CMakeLists.txt
+++ b/gtdynamics/CMakeLists.txt
@@ -82,6 +82,7 @@ target_include_directories(gtdynamics PUBLIC ${SDFormat_INCLUDE_DIRS})
 ## Install library and headers.
 install(
   TARGETS gtdynamics
+  EXPORT "${PROJECT_NAME}-exports"
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin)


### PR DESCRIPTION
This PR adds support for making `gtdynamics` a cmake package so we can do `find_package(gtdynamics)` for downstream applications. Fixes #5.

I need this for my own LRSE project and it's been long overdue.
To include gtdynamics, all I needed to do was `find_package(gtdynamics REQUIRED)` and when I print the version as `${gtdynamics_VERSION}`, I get the following output:

```
-- GTSAM include directory:  /usr/local/lib/cmake/GTSAM/../../../include
-- Looking for ignition-math6 -- found version 6.9.2
-- Searching for dependencies of ignition-math6
-- GTSAM Version: 4.2a4
-- GTDynamics Version: 1.0.0
```

This is a CMake update and no C++ changes are made whatsoever. Moreover, it includes commands for configuring and installing mainly 3 files: `gtdynamics-exports.cmake`, `gtdynamicsConfig.cmake` and `gtdynamicsConfigVersion.cmake`. Thus, there should be no breakage in the normal process of installation from source. Even the CI should be evidence of this since we install from source.

Question: Should we stick to `gtdynamics` or convert the package name to `GTDynamics`? The former means we have CMake variables of the form `gtdynamics_VERSION` which is fine IMO, but we can do `GTDynamics_VERSION` instead if you'd like.
GTSAM does `GTSAM_VERSION` but it is also a shorter name.