### PR TITLE
Improvements to ContactEqualityFactor

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -57,7 +57,7 @@ class ForwardKinematicsFactor : gtsam::NoiseModelFactor {
 class ContactEqualityFactor : gtsam::NoiseModelFactor {
   ContactEqualityFactor(const gtdynamics::PointOnLink &point_on_link,
                         const gtsam::noiseModel::Base *model, size_t k1,
-                        size_t k2, bool enforce_equality = true);
+                        size_t k2);
 
   void print(const string &s = "", const gtsam::KeyFormatter &keyFormatter =
                                        gtdynamics::GTDKeyFormatter);

--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -57,7 +57,7 @@ class ForwardKinematicsFactor : gtsam::NoiseModelFactor {
 class ContactEqualityFactor : gtsam::NoiseModelFactor {
   ContactEqualityFactor(const gtdynamics::PointOnLink &point_on_link,
                         const gtsam::noiseModel::Base *model, size_t k1,
-                        size_t k2);
+                        size_t k2, bool enforce_equality = true);
 
   void print(const string &s = "", const gtsam::KeyFormatter &keyFormatter =
                                        gtdynamics::GTDKeyFormatter);

--- a/gtdynamics/factors/ContactEqualityFactor.h
+++ b/gtdynamics/factors/ContactEqualityFactor.h
@@ -40,12 +40,6 @@ class ContactEqualityFactor
   /// The point on the link at which to enforce equality.
   PointOnLink point_on_link_;
 
-  /**
-   * Flag to enforce the factor. If false, then factor returns zero error.
-   * Used primarily for hybrid elimination.
-   */
-  bool enforce_equality_;
-
  public:
   // shorthand for a smart pointer to a factor
   using shared_ptr = typename boost::shared_ptr<ContactEqualityFactor>;
@@ -61,16 +55,13 @@ class ContactEqualityFactor
    * @param model            The noise model for this factor.
    * @param k1               First time index.
    * @param k2               Subsequent time index.
-   * @param enforce_equality Flag indicating if the equality should be
-   * enforced.
    */
   ContactEqualityFactor(const PointOnLink &point_on_link,
                         const gtsam::SharedNoiseModel &model, size_t k1,
-                        size_t k2, bool enforce_equality = true)
+                        size_t k2)
       : Base(model, PoseKey(point_on_link.link->id(), k1),
              PoseKey(point_on_link.link->id(), k2)),
-        point_on_link_(point_on_link),
-        enforce_equality_(enforce_equality) {}
+        point_on_link_(point_on_link) {}
 
   ~ContactEqualityFactor() override {}
 
@@ -97,11 +88,7 @@ class ContactEqualityFactor
       const gtsam::Pose3 &wT1, const gtsam::Pose3 &wT2,
       boost::optional<gtsam::Matrix &> H1 = boost::none,
       boost::optional<gtsam::Matrix &> H2 = boost::none) const override {
-    if (enforce_equality_) {
-      return contactPointsDifference(wT1, wT2, H1, H2);
-    }
-    // If equality is not enforced then set error to zero.
-    return gtsam::Vector::Zero(3);
+    return contactPointsDifference(wT1, wT2, H1, H2);
   }
 
   /// print contents
@@ -117,8 +104,7 @@ class ContactEqualityFactor
               double tol = 1e-9) const override {
     const This *e = dynamic_cast<const This *>(&other);
     return e != nullptr && Base::equals(*e, tol) &&
-           point_on_link_.equals(e->point_on_link_) &&
-           enforce_equality_ == e->enforce_equality_;
+           point_on_link_.equals(e->point_on_link_);
   }
 };
 

--- a/gtdynamics/utils/JsonSaver.h
+++ b/gtdynamics/utils/JsonSaver.h
@@ -17,7 +17,6 @@
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/slam/PriorFactor.h>
 
-#include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <fstream>
 #include <iostream>

--- a/gtdynamics/utils/JsonSaver.h
+++ b/gtdynamics/utils/JsonSaver.h
@@ -17,6 +17,7 @@
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/slam/PriorFactor.h>
 
+#include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <fstream>
 #include <iostream>
@@ -199,12 +200,12 @@ class JsonSaver {
   static inline std::string GetMeasurement(
       const gtsam::NonlinearFactor::shared_ptr& factor) {
     std::stringstream ss;
-    // if (const TorqueFactor* f = dynamic_cast<const TorqueFactor*>(&(*factor))) {
-      // auto joint = f->getJoint();
-      // ss << GetVector(joint->screwAxis(joint->child()).transpose());
+    // if (const TorqueFactor* f = dynamic_cast<const
+    // TorqueFactor*>(&(*factor))) { auto joint = f->getJoint(); ss <<
+    // GetVector(joint->screwAxis(joint->child()).transpose());
     if (const gtsam::PriorFactor<gtsam::Vector3>* f =
-                   dynamic_cast<const gtsam::PriorFactor<gtsam::Vector3>*>(
-                       &(*factor))) {
+            dynamic_cast<const gtsam::PriorFactor<gtsam::Vector3>*>(
+                &(*factor))) {
       ss << GetVector(f->prior().transpose());
     } else if (const gtsam::PriorFactor<gtsam::Vector6>* f =
                    dynamic_cast<const gtsam::PriorFactor<gtsam::Vector6>*>(


### PR DESCRIPTION
The `ContactEqualityFactor` is a bit half-baked (which is my fault) so making amends with this PR. Added traits and a bunch of other niceties to make it work in proper optimization.

~~The most important change is the flag `enforce_equality_` which if set to true activates the factor, else returns error zero.
This is so that it can be used directly with the `DCMixtureFactor` where it is set to true for stance feet and false for everything else.~~