### PR TITLE
Set default flag to false for preserve_fixed_joint

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -270,7 +270,8 @@ class Robot {
 #include <gtdynamics/universal_robot/sdf.h>
 // Only SDF files require the model_name specified..
 gtdynamics::Robot CreateRobotFromFile(const string &urdf_file_path,
-                                      const string &model_name = "");
+                                      const string &model_name = "",
+                                      bool preserve_fixed_joint = false);
 
 /********************** utilities **********************/
 #include <gtdynamics/utils/PointOnLink.h>

--- a/gtdynamics/universal_robot/sdf.h
+++ b/gtdynamics/universal_robot/sdf.h
@@ -29,6 +29,6 @@ namespace gtdynamics {
  */
 Robot CreateRobotFromFile(const std::string &file_path,
                           const std::string &model_name = "",
-                          bool preserve_fixed_joint = true);
+                          bool preserve_fixed_joint = false);
 
 }  // namespace gtdynamics

--- a/python/tests/test_chain.py
+++ b/python/tests/test_chain.py
@@ -37,10 +37,10 @@ class TestChain(GtsamTestCase):
 
         # FK at rest
         self.gtsamAssertEquals(joint1.poe([0]), sMb)
-        sTb = Pose3(Rot3.Rz(np.pi/2), Point3(0, 5, 0))
+        sTb = Pose3(Rot3.Rz(np.pi / 2), Point3(0, 5, 0))
 
         # FK not at rest
-        q = [np.pi/2]
+        q = [np.pi / 2]
         self.gtsamAssertEquals(joint1.poe(q), sTb)
         J = np.zeros((6, 1))
         self.gtsamAssertEquals(joint1.poe(q, J=J), sTb)
@@ -57,10 +57,8 @@ class TestChain(GtsamTestCase):
         sM3, J3 = three_links.spec()
         expected = Pose3(Rot3(), Point3(15, 0, 0))
         self.gtsamAssertEquals(sM3, expected)
-        expected_J3 = np.array(
-            [[0, 0, 1, 0, 15, 0],
-             [0, 0, 1, 0, 10,  0],
-             [0, 0, 1, 0, 5,  0]]).transpose()
+        expected_J3 = np.array([[0, 0, 1, 0, 15, 0], [0, 0, 1, 0, 10, 0],
+                                [0, 0, 1, 0, 5, 0]]).transpose()
         np.testing.assert_allclose(J3, expected_J3)
 
         # FK at rest
@@ -68,15 +66,13 @@ class TestChain(GtsamTestCase):
         self.gtsamAssertEquals(three_links.poe([0, 0, 0]), expected)
 
         # FK not at rest
-        q = np.array([0, 0, np.pi/2])
-        sT3 = Pose3(Rot3.Rz(np.pi/2), Point3(10, 5, 0))
+        q = np.array([0, 0, np.pi / 2])
+        sT3 = Pose3(Rot3.Rz(np.pi / 2), Point3(10, 5, 0))
         self.gtsamAssertEquals(three_links.poe(q), sT3)
         expected_J1 = sT3.inverse().Adjoint(axis(0, 0, 1, 0, 0, 0))
         np.testing.assert_allclose(expected_J1, [0, 0, 1, 10, 5, 0])
         expected_J = np.array(
-            [expected_J1,
-             [0, 0, 1, 5, 5,  0],
-             [0, 0, 1, 0, 5,  0]]).transpose()
+            [expected_J1, [0, 0, 1, 5, 5, 0], [0, 0, 1, 0, 5, 0]]).transpose()
         J = np.zeros((6, 3))
         self.gtsamAssertEquals(three_links.poe(q, J=J), sT3)
         np.testing.assert_allclose(J, expected_J)
@@ -98,7 +94,7 @@ class TestPanda(GtsamTestCase):
         # Create chain sub-system
         self.chain = Chain.from_robot(ROBOT, BASE_NAME)
 
-    @ staticmethod
+    @staticmethod
     def JointAngles(q: list):
         """Create Values with joint angles."""
         joint_angles = Values()
@@ -113,16 +109,12 @@ class TestPanda(GtsamTestCase):
         self.assertTrue(ROBOT.link("link0").isFixed())
 
         # Check FK at rest, Conventional FK with GTSAM.
-        joint_angles = self.JointAngles(np.zeros((7,)))
+        joint_angles = self.JointAngles(np.zeros((7, )))
         fk = ROBOT.forwardKinematics(joint_angles, 0, BASE_NAME)
         # Use this to print: fk.print("fk", gtd.GTDKeyFormatter)
-        sR7 = Rot3([
-            [1, 0, 0],
-            [0, -1, 0],
-            [0, 0, -1]
-        ])
+        sR7 = Rot3([[1, 0, 0], [0, -1, 0], [0, 0, -1]])
         #regression
-        expected_sM7 = Pose3(sR7, Point3(0.098517, 0.004252, 0.971403))
+        expected_sM7 = Pose3(sR7, Point3(0.0882972, 0.00213401, 0.933844))
         actual_sM7 = gtd.Pose(fk, 7)
         self.gtsamAssertEquals(actual_sM7, expected_sM7, tol=1e-3)
 
@@ -132,13 +124,13 @@ class TestPanda(GtsamTestCase):
 
         # Check Panda twist in end-effector frame
         self.assertEqual(J7.shape, (6, 7))
-        expected_J7 = np.array([[0, 0, -1, -0.004252, -0.0985, 0],
-                                [0, -1, 0, 0.6384, 0, 0.0985],
-                                [0, 0, -1, -0.00425, -0.0985, 0],
-                                [0, 1, 0, -0.322, 0, -0.016],
-                                [0, 0, -1, -0.00425, -0.0985, 0],
-                                [0, 1, 0, 0.06159, 0, -0.0985],
-                                [0, 0, 1, 0.00425, 0.0105, 0]]).transpose()
+        expected_J7 = np.array([[0, 0, -1, -0.002, -0.088, 0],
+                                [0, -1, 0, 0.601, 0, 0.088],
+                                [0, 0, -1, -0.002, -0.088, 0],
+                                [0, 1, 0, -0.285, 0, -0.006],
+                                [0, 0, -1, -0.002, -0.088, 0],
+                                [0, 1, 0, 0.099, 0, -0.088],
+                                [0, 0, 1, 0.002, 0, 0]]).transpose()
         #regression
         np.testing.assert_allclose(J7, expected_J7, atol=0.001)
 
@@ -172,7 +164,7 @@ class TestPanda(GtsamTestCase):
         q_list[6] += 0.00001
         q = np.array(q_list)
         sT7_plus = self.chain.poe(q, fTe=fTe)
-        xi = sT7.logmap(sT7_plus)/0.00001
+        xi = sT7.logmap(sT7_plus) / 0.00001
         np.testing.assert_allclose(poe_J[:, 6], xi, atol=0.01)
 
     def test_forward_kinematics_at_rest(self):
@@ -186,16 +178,16 @@ class TestPanda(GtsamTestCase):
 
     def test_forward_kinematics_joint0(self):
         """Test forward kinematics with non-zero joint0 angle."""
-        self.check_poe([np.pi/2, 0, 0, 0, 0, 0, 0])
+        self.check_poe([np.pi / 2, 0, 0, 0, 0, 0, 0])
 
     def test_forward_kinematics_joint0_with_offset(self):
         """FK with non-zero joint0, with offset."""
         fTe = Pose3(Rot3.Ry(0.1), Point3(1, 2, 3))
-        self.check_poe([np.pi/2, 0, 0, 0, 0, 0, 0], fTe)
+        self.check_poe([np.pi / 2, 0, 0, 0, 0, 0, 0], fTe)
 
     def test_forward_kinematics_middle(self):
         """Test forward kinematics with middle joint rotated."""
-        self.check_poe([0, 0, 0, 0, np.pi/2, 0, 0])
+        self.check_poe([0, 0, 0, 0, np.pi / 2, 0, 0])
 
     def test_forward_kinematics_random(self):
         """Test forward kinematics with random configuration."""

--- a/python/tests/test_panda.py
+++ b/python/tests/test_panda.py
@@ -46,7 +46,7 @@ class TestSerial(GtsamTestCase):
             [0, 0, -1]
         ])
         # regression
-        expected_sT7 = Pose3(sR7, Point3(0.139535, 0.004392, 0.921429))
+        expected_sT7 = Pose3(sR7, Point3(0.129315, 0.00227401, 0.88387))
         actual_sT7 = gtd.Pose(fk, 7)
         self.gtsamAssertEquals(actual_sT7, expected_sT7, tol=1e-3)
 

--- a/python/tests/test_robot.py
+++ b/python/tests/test_robot.py
@@ -29,7 +29,7 @@ class TestRobot(GtsamTestCase):
 
     def test_fixed_joint(self):
         """Test if the fixed joint is parsed correctly."""
-        robot = gtd.CreateRobotFromFile(self.ROBOT_MODEL)
+        robot = gtd.CreateRobotFromFile(self.ROBOT_MODEL, "", True)
         # Try to get the fixed links
         self.assertIsNotNone(robot.link("FR_toe"))
         self.assertIsNotNone(robot.link("FL_toe"))
@@ -164,6 +164,9 @@ class TestRobot(GtsamTestCase):
         # Test all the links
         for link in robot.links():
             lTcom = lTcom_adjustments[link.name()]
+            if "_lower" in link.name():
+                lTcom = lTcom.compose(lowerTcom)
+
             bTl = bTl_poses[link.name()]
             expected_bTcom = bTl.compose(lTcom)
 

--- a/tests/testFixedJoint.cpp
+++ b/tests/testFixedJoint.cpp
@@ -39,7 +39,7 @@ TEST(FixedJoint, Constructor) {
 }
 
 TEST(FixedJoint, A1) {
-  Robot a1 = CreateRobotFromFile(kUrdfPath + std::string("a1/a1.urdf"));
+  Robot a1 = CreateRobotFromFile(kUrdfPath + std::string("a1/a1.urdf"), "", true);
   std::string joint_name = "FR_toe_fixed";
   EXPECT(a1.joint("FR_toe_fixed")->name() == "FR_toe_fixed");
 }

--- a/tests/testSdf.cpp
+++ b/tests/testSdf.cpp
@@ -648,6 +648,16 @@ TEST(Sdf, sdf_constructor) {
       l1.inertia()));
 }
 
+TEST(Sdf, PreserveFixedJoint) {
+  // // Get the A1 robot with fixed joints lumped together.
+  Robot a1 = CreateRobotFromFile(kUrdfPath + std::string("a1/a1.urdf"));
+  EXPECT_LONGS_EQUAL(12, a1.numJoints());
+
+  Robot a1_fixed_joints =
+      CreateRobotFromFile(kUrdfPath + std::string("a1/a1.urdf"), "", true);
+  EXPECT_LONGS_EQUAL(21, a1_fixed_joints.numJoints());
+}
+
 int main() {
   TestResult tr;
   return TestRegistry::runAllTests(tr);


### PR DESCRIPTION
As discussed in today's meeting, setting the `preserve_fixed_joint` flag to false by default.

I added a bunch of unit tests and also wrapped this in Python.