### PR TITLE
fix jointIndex syntax error

### DIFF
--- a/python/gtdynamics/sim.py
+++ b/python/gtdynamics/sim.py
@@ -23,7 +23,7 @@ def set_joint_angles(pyb,
     """
     for joint_id in joint_to_jid_map.values():
         pyb.setJointMotorControl2(bodyUniqueId=robot,
-                                  jointindex=joint_id,
+                                  jointIndex=joint_id,
                                   controlMode=pyb.VELOCITY_CONTROL,
                                   force=force)
 


### PR DESCRIPTION
Hi all! I noticed there was a small syntax error in sim.py when I was running `python kinematic_mp_sim.py` for the quadruped. I was getting `TypeError: function missing required argument 'bodyIndex' (pos 1)` and noticed that the `bodyindex` param did not have the right capitalization, so here's a quick fix.