### PR TITLE
Manifold Optimization example for cable robot

### DIFF
--- a/scripts/gerry01_cablerobot_manifold.cpp
+++ b/scripts/gerry01_cablerobot_manifold.cpp
@@ -1,0 +1,347 @@
+/* ----------------------------------------------------------------------------
+ * GTDynamics Copyright 2020, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file  cablerobot_manifold.cpp
+ * @brief Kinematic trajectory planning problem of reaching a target pose with a
+ * cable robot. Benchmarking dynamic factor graph, constraint manifold, manually
+ * specified manifold.
+ * @author Yetong Zhang
+ * @author Gerry Chen
+ */
+
+#include <gtdynamics/dynamics/DynamicsGraph.h>
+#include <gtdynamics/factors/JointLimitFactor.h>
+#include <gtdynamics/factors/PointGoalFactor.h>
+#include <gtdynamics/cablerobot/factors/CableLengthFactor.h>
+#include <gtdynamics/cablerobot/factors/CableVelocityFactor.h>
+#include <gtdynamics/cablerobot/factors/CableTensionFactor.h>
+#include <gtdynamics/optimizer/ManifoldOptimizerType1.h>
+#include <gtdynamics/universal_robot/RobotModels.h>
+#include <gtdynamics/universal_robot/SerialChain.h>
+#include <gtsam/base/timing.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/slam/BetweenFactor.h>
+
+using namespace gtsam;
+using namespace gtdynamics;
+
+const size_t num_steps = 10;
+auto joint_noise = noiseModel::Isotropic::Sigma(1, 1.0);
+auto joint_limit_noise = noiseModel::Isotropic::Sigma(1, 1e-2);
+auto target_noise = noiseModel::Isotropic::Sigma(6, 1e-2);
+
+const double kCdprWidth = 3, kCdprHeight = 2;
+const std::array<Point3, 4> kCdprFrameMountPoints = {
+    Point3{kCdprWidth, 0, 0},  //
+    Point3{kCdprWidth, kCdprHeight, 0},
+    Point3{0, kCdprHeight, 0},
+    Point3{0, 0, 0}};
+const double kCdprEeWidth = 0.1, kCdprEeHeight = 0.1;
+const std::array<Point3, 4> kCdprEeMountPoints = {
+    Point3{kCdprEeWidth, 0, 0},
+    Point3{kCdprEeWidth, kCdprEeHeight, 0},
+    Point3{0, kCdprEeHeight, 0},
+    Point3{0, 0, 0}};
+
+const Key kEeId = 1;
+const Pose3 target_pose = Pose3(Rot3(), Point3(0.2, 0.5, 0.0));
+// const Pose3 base_pose;
+double joint_limit_low = 0;
+double joint_limit_high = 3.6;
+
+/** compute error for joint limit error, to reproduce joint limit factor in
+ * expressions. */
+class JointLimitFunctor {
+ protected:
+  double low_, high_;
+
+ public:
+  JointLimitFunctor(const double& low, const double& high)
+      : low_(low), high_(high) {}
+
+  double operator()(const double& q,
+                    OptionalJacobian<1, 1> H_q = boost::none) const {
+    if (q < low_) {
+      if (H_q) *H_q = -gtsam::I_1x1;
+      return low_ - q;
+    } else if (q <= high_) {
+      if (H_q) *H_q = gtsam::Z_1x1;
+      return 0.0;
+    } else {
+      if (H_q) *H_q = gtsam::I_1x1;
+      return q - high_;
+    }
+  }
+};
+
+/** Kinematic trajectory optimization using dynamics factor graph. */
+Values optimize_dynamics_graph(const NonlinearFactorGraph& constraints_graph,
+                               const NonlinearFactorGraph& costs,
+                               const Values& init_values) {
+  NonlinearFactorGraph graph;
+  graph.add(constraints_graph);
+  graph.add(costs);
+
+  LevenbergMarquardtParams params;
+  params.setVerbosityLM("SUMMARY");
+  LevenbergMarquardtOptimizer optimizer(graph, init_values, params);
+  gttic_(dynamic_factor_graph);
+  auto result = optimizer.optimize();
+  gttoc_(dynamic_factor_graph);
+
+  size_t graph_dim = 0;
+  for (const auto& factor : graph) {
+    graph_dim += factor->dim();
+  }
+  std::cout << "dimension: " << graph_dim << " x " << init_values.dim() << "\n";
+  return result;
+}
+
+/** Kinematic trajectory optimization using constraint manifold. */
+Values optimize_constraint_manifold(
+    const NonlinearFactorGraph& constraints_graph,
+    const NonlinearFactorGraph& costs, const Values& init_values) {
+  auto constraints = ConstraintsFromGraph(constraints_graph);
+
+  LevenbergMarquardtParams params;
+  params.setVerbosityLM("SUMMARY");
+  // params.minModelFidelity = 0.1;
+  std::cout << "building optimizer\n";
+  ManifoldOptimizerType1 optimizer(costs, constraints, init_values, params);
+  std::cout << "optimize\n";
+  gttic_(constraint_manifold);
+  auto result = optimizer.optimize();
+  gttoc_(constraint_manifold);
+
+  auto problem_dim = optimizer.problem_dimension();
+  std::cout << "dimension: " << problem_dim.first << " x " << problem_dim.second
+            << "\n";
+  return result;
+}
+
+/** Kinematic trajectory optimization using manually defined serial chain
+ * manifold. */
+Values optimize_serial_chain_manifold(const NonlinearFactorGraph& costs,
+                                      const Values& init_values) {
+  LevenbergMarquardtParams params;
+  params.setVerbosityLM("SUMMARY");
+  size_t graph_dim = 0;
+  for (const auto& factor : costs) {
+    graph_dim += factor->dim();
+  }
+  std::cout << "dimension: " << graph_dim << " x " << init_values.dim() << "\n";
+  LevenbergMarquardtOptimizer optimizer(costs, init_values, params);
+  gttic_(serial_chain_manifold);
+  auto result = optimizer.optimize();
+  gttoc_(serial_chain_manifold);
+  return result;
+}
+
+/** Factor graph of all kinematic constraints. */
+NonlinearFactorGraph get_constraints_graph() {
+  NonlinearFactorGraph constraints_graph;
+  auto graph_builder = DynamicsGraph(); // 
+  // kinematics constraints at each step
+  for (size_t k = 0; k <= num_steps; ++k) {
+    for (size_t ci = 0; ci < 4; ++ci) {
+      constraints_graph.emplace_shared<CableLengthFactor>(
+          JointAngleKey(ci, k), PoseKey(kEeId, k),
+          gtsam::noiseModel::Isotropic::Sigma(1, 0.001),
+          kCdprFrameMountPoints[ci], kCdprEeMountPoints[ci]);
+    }
+  }
+  // constraints_graph.print("constraints_graph", GTDKeyFormatter);
+  // // prior constraints at first step
+  constraints_graph.addPrior(PoseKey(kEeId, 0),
+                             Pose3(Rot3(), Point3(1.5, 1.0, 0)),
+                             gtsam::noiseModel::Isotropic::Sigma(6, 0.001));
+  return constraints_graph;
+}
+
+/** Cost. */
+NonlinearFactorGraph get_costs() {
+  NonlinearFactorGraph costs;
+  // rotation costs
+  NonlinearFactorGraph rotation_costs;
+  for (size_t k = 0; k < num_steps; k++) {
+    for (size_t ci = 0; ci < 4; ++ci) {
+      rotation_costs.emplace_shared<BetweenFactor<double>>(
+          JointAngleKey(ci, k), JointAngleKey(ci, k + 1), 0.0, joint_noise);
+    }
+  }
+  // joint limit costs;
+  NonlinearFactorGraph joint_limit_costs;
+  for (size_t k = 0; k <= num_steps; k++) {
+    for (size_t ci = 0; ci < 4; ++ci) {
+      joint_limit_costs.emplace_shared<JointLimitFactor>(
+          JointAngleKey(ci, k), joint_limit_noise, joint_limit_low,
+          joint_limit_high, 0.0);
+    }
+  }
+  // target cost
+  NonlinearFactorGraph target_costs;
+  costs.addPrior(PoseKey(kEeId, num_steps), target_pose, target_noise);
+  // Point3 point_com(0, 0, 0.1);
+  // Point3 target_point(0.0, 0.7, 0.7);
+  // target_costs.emplace_shared<PointGoalFactor>(
+  //     PoseKey(ee_link->id(), num_steps), target_noise, point_com,
+  //     target_point);
+  costs.add(rotation_costs);
+  costs.add(target_costs);
+  costs.add(joint_limit_costs);
+  return costs;
+}
+
+/** Initial values specifed by 0 for all joint angles. */
+Values get_init_values() {
+  Values init_values;
+  for (size_t k = 0; k <= num_steps; k++) {
+    for (size_t ci = 0; ci < 4; ++ci) {
+      InsertJointAngle(&init_values, ci, k, 1.8);
+    }
+    InsertPose(&init_values, kEeId, k, Pose3(Rot3(), Point3(1.5, 1.0, 0)));
+  }
+  return init_values;
+}
+
+// /** Initial values of serial chain specifed by 0 for all joint angles. */
+// Values get_init_values_sc() {
+//   Values init_values;
+//   auto shared_robot = boost::make_shared<Robot>(robot);
+//   Values joint_angles;
+//   for (const auto& joint : robot.joints()) {
+//     gtdynamics::InsertJointAngle(&joint_angles, joint->id(), 0.0);
+//   }
+//   for (size_t k = 1; k <= num_steps; k++) {
+//     Key sc_key = k;
+//     init_values.insert(sc_key, SerialChain<7>(shared_robot, base_name,
+//                                               base_pose, joint_angles));
+//   }
+//   return init_values;
+// }
+
+// NonlinearFactorGraph get_costs_sc() {
+//   NonlinearFactorGraph costs;
+//   // rotation costs
+//   Expression<SerialChain<7>> state1(1);
+//   for (const auto& joint : robot.joints()) {
+//     auto joint_func = std::bind(&SerialChain<7>::joint, std::placeholders::_1,
+//                                 joint->name(), std::placeholders::_2);
+//     Expression<double> curr_joint(joint_func, state1);
+//     costs.addExpressionFactor<double>(joint_noise, 0.0, curr_joint);
+//   }
+//   for (size_t k = 1; k < num_steps; k++) {
+//     Key curr_key = k;
+//     Key next_key = k + 1;
+//     Expression<SerialChain<7>> curr_state(curr_key);
+//     Expression<SerialChain<7>> next_state(next_key);
+//     for (const auto& joint : robot.joints()) {
+//       auto joint_func = std::bind(&SerialChain<7>::joint, std::placeholders::_1,
+//                                   joint->name(), std::placeholders::_2);
+//       Expression<double> curr_joint(joint_func, curr_state);
+//       Expression<double> next_joint(joint_func, next_state);
+//       Expression<double> joint_rotation_expr = next_joint - curr_joint;
+//       costs.addExpressionFactor<double>(joint_noise, 0.0, joint_rotation_expr);
+//     }
+//   }
+
+//   // joint limit costs
+//   JointLimitFunctor joint_limit_functor(joint_limit_low, joint_limit_high);
+//   for (size_t k = 1; k <= num_steps; k++) {
+//     Key curr_key = k;
+//     Expression<SerialChain<7>> curr_state(curr_key);
+//     for (const auto& joint : robot.joints()) {
+//       auto joint_func = std::bind(&SerialChain<7>::joint, std::placeholders::_1,
+//                                   joint->name(), std::placeholders::_2);
+//       Expression<double> curr_joint(joint_func, curr_state);
+//       Expression<double> joint_limit_error(joint_limit_functor, curr_joint);
+//       costs.addExpressionFactor<double>(joint_limit_noise, 0.0,
+//                                         joint_limit_error);
+//     }
+//   }
+
+//   // target costs
+//   Key last_key = num_steps;
+//   Expression<SerialChain<7>> last_state(last_key);
+//   auto pose_func = std::bind(&SerialChain<7>::link_pose, std::placeholders::_1,
+//                              ee_name, std::placeholders::_2);
+//   Expression<Pose3> target_pose_expr(pose_func, last_state);
+//   costs.addExpressionFactor<Pose3>(target_noise, target_pose, target_pose_expr);
+//   return costs;
+// }
+
+/** Print joint angles for all steps. */
+void print_joint_angles(const Values& values) {
+  for (size_t k = 0; k <= num_steps; k++) {
+    std::cout << "step " << k << ": ";
+    for (size_t ci = 0; ci < 4; ++ci) {
+      double angle = JointAngle(values, ci, k);
+      std::cout << "\t" << angle;
+    }
+    std::cout << "\n";
+  }
+}
+
+// /** Print joint angles of serial chain for all steps. */
+// void print_joint_angles_sc(const Values& values) {
+//   for (size_t k = 1; k <= num_steps; k++) {
+//     Key state_key = k;
+//     auto state = values.at<SerialChain<7>>(state_key);
+//     std::cout << "step " << k << ":";
+//     for (const auto& joint : robot.joints()) {
+//       double angle = state.joint(joint->name());
+//       std::cout << "\t" << angle;
+//     }
+//     std::cout << "\n";
+//   }
+// }
+
+/** Compare simple kinematic planning tasks of a robot arm using (1) dynamics
+ * factor graph (2) constraint manifold (3) manually specifed serial chain
+ * manifold. */
+void kinematic_planning() {
+  // problem
+  auto constraints_graph = get_constraints_graph();
+  auto costs = get_costs();
+  auto init_values = get_init_values();
+
+  // optimize dynamics graph
+  std::cout << "dynamics graph:\n";
+  auto dfg_result =
+      optimize_dynamics_graph(constraints_graph, costs, init_values);
+  std::cout << "final cost: " << costs.error(dfg_result) << "\n";
+  std::cout << "constraint violation: " << constraints_graph.error(dfg_result)
+            << "\n";
+  print_joint_angles(dfg_result);
+
+  // optimize constraint manifold
+  std::cout << "constraint manifold:\n";
+  auto cm_result =
+      optimize_constraint_manifold(constraints_graph, costs, init_values);
+  std::cout << "final cost: " << costs.error(cm_result) << "\n";
+  std::cout << "constraint violation: " << constraints_graph.error(cm_result)
+            << "\n";
+  print_joint_angles(cm_result);
+
+  // // optimize serial chain manifold
+  // std::cout << "serial chain manifold\n";
+  // Values sc_init_values = get_init_values_sc();
+  // auto sc_costs = get_costs_sc();
+  // auto sc_result = optimize_serial_chain_manifold(sc_costs, sc_init_values);
+  // std::cout << "final cost: " << sc_costs.error(sc_result) << "\n";
+  // print_joint_angles_sc(sc_result);
+
+  std::cout << "Timing results:\n";
+  tictoc_finishedIteration_();
+  tictoc_print_();
+}
+
+int main(int argc, char** argv) {
+  kinematic_planning();
+  return 0;
+}


### PR DESCRIPTION
Currently the kinematics version works great!  Comparing just the "normal gtdynamics" version with the constraint manifold version.  Currently not using serial chain, but will update PR description once I do implement that.

Results (ugly-pasted, will clean up):

```
dynamics graph:
Initial error: 159912, values: 55
iter      cost      cost_change    lambda  success iter_time
   0      inf    2.12e-314    1.00e-05     0    9.47e-04
iter      cost      cost_change    lambda  success iter_time
   0      inf    2.12e-314    1.00e-04     0    1.61e-04
iter      cost      cost_change    lambda  success iter_time
   0      inf    2.12e-314    1.00e-03     0    1.52e-04
iter      cost      cost_change    lambda  success iter_time
   0      inf    2.12e-314    1.00e-02     0    2.52e-04
iter      cost      cost_change    lambda  success iter_time
   0  2.231055e+05   -6.32e+04    1.00e-01     1    5.51e-04
iter      cost      cost_change    lambda  success iter_time
   0  1.759375e+05   -1.60e+04    1.00e+00     1    5.98e-04
iter      cost      cost_change    lambda  success iter_time
   0  1.716523e+05   -1.17e+04    1.00e+01     1    4.84e-04
iter      cost      cost_change    lambda  success iter_time
   0  1.507274e+05    9.19e+03    1.00e+02     1    5.37e-04
   1  4.316304e+00    1.51e+05    1.00e+01     1    4.80e-04
   2  8.227840e+02   -8.18e+02    1.00e+00     1    4.65e-04
   2  2.628679e+00    1.69e+00    1.00e+01     1    4.61e-04
   3  6.081017e+02   -6.05e+02    1.00e+00     1    7.17e-04
   3  2.197412e+00    4.31e-01    1.00e+01     1    6.49e-04
   4  4.523703e+02   -4.50e+02    1.00e+00     1    5.56e-04
   4  1.885185e+00    3.12e-01    1.00e+01     1    5.22e-04
   5  3.390384e+02   -3.37e+02    1.00e+00     1    5.00e-04
   5  1.653599e+00    2.32e-01    1.00e+01     1    5.03e-04
   6  2.563842e+02   -2.55e+02    1.00e+00     1    4.94e-04
   6  1.478307e+00    1.75e-01    1.00e+01     1    6.56e-04
   7  1.959292e+02   -1.94e+02    1.00e+00     1    5.92e-04
   7  1.343096e+00    1.35e-01    1.00e+01     1    5.88e-04
   8  1.515142e+02   -1.50e+02    1.00e+00     1    5.64e-04
   8  1.236832e+00    1.06e-01    1.00e+01     1    5.73e-04
   9  1.186781e+02   -1.17e+02    1.00e+00     1    5.55e-04
   9  1.151735e+00    8.51e-02    1.00e+01     1    5.64e-04
  10  9.420535e+01   -9.31e+01    1.00e+00     1    5.53e-04
  10  1.082305e+00    6.94e-02    1.00e+01     1    5.61e-04
  11  7.578853e+01   -7.47e+01    1.00e+00     1    5.51e-04
  11  1.024622e+00    5.77e-02    1.00e+01     1    5.62e-04
  12  6.177645e+01   -6.08e+01    1.00e+00     1    5.54e-04
  12  9.758742e-01    4.87e-02    1.00e+01     1    5.02e-04
  13  5.098837e+01   -5.00e+01    1.00e+00     1    4.90e-04
  13  9.340260e-01    4.18e-02    1.00e+01     1    4.95e-04
  14  4.257895e+01   -4.16e+01    1.00e+00     1    4.88e-04
  14  8.975908e-01    3.64e-02    1.00e+01     1    5.01e-04
  15  3.594103e+01   -3.50e+01    1.00e+00     1    4.92e-04
  15  8.654711e-01    3.21e-02    1.00e+01     1    5.02e-04
  16  3.063633e+01   -2.98e+01    1.00e+00     1    6.00e-04
  16  8.368470e-01    2.86e-02    1.00e+01     1    5.41e-04
  17  2.634637e+01   -2.55e+01    1.00e+00     1    5.18e-04
  17  8.110976e-01    2.57e-02    1.00e+01     1    6.09e-04
  18  2.283788e+01   -2.20e+01    1.00e+00     1    5.25e-04
  18  7.877462e-01    2.34e-02    1.00e+01     1    5.05e-04
  19  1.993842e+01   -1.92e+01    1.00e+00     1    4.41e-04
  19  7.664218e-01    2.13e-02    1.00e+01     1    4.45e-04
  20  1.751922e+01   -1.68e+01    1.00e+00     1    4.37e-04
  20  7.468311e-01    1.96e-02    1.00e+01     1    4.42e-04
  21  1.548305e+01   -1.47e+01    1.00e+00     1    4.36e-04
  21  7.287392e-01    1.81e-02    1.00e+01     1    4.43e-04
  22  1.375572e+01   -1.30e+01    1.00e+00     1    4.32e-04
  22  7.119554e-01    1.68e-02    1.00e+01     1    4.41e-04
  23  1.227990e+01   -1.16e+01    1.00e+00     1    4.32e-04
  23  6.963228e-01    1.56e-02    1.00e+01     1    4.41e-04
  24  1.101086e+01   -1.03e+01    1.00e+00     1    4.33e-04
  24  6.817111e-01    1.46e-02    1.00e+01     1    4.39e-04
  25  9.913283e+00   -9.23e+00    1.00e+00     1    4.35e-04
  25  6.680106e-01    1.37e-02    1.00e+01     1    4.41e-04
  26  8.958983e+00   -8.29e+00    1.00e+00     1    4.36e-04
  26  6.551281e-01    1.29e-02    1.00e+01     1    4.31e-04
  27  8.125269e+00   -7.47e+00    1.00e+00     1    3.96e-04
  27  6.429839e-01    1.21e-02    1.00e+01     1    4.03e-04
  28  7.393695e+00   -6.75e+00    1.00e+00     1    3.98e-04
  28  6.315091e-01    1.15e-02    1.00e+01     1    4.03e-04
  29  6.749139e+00   -6.12e+00    1.00e+00     1    3.97e-04
  29  6.206440e-01    1.09e-02    1.00e+01     1    4.83e-04
  30  6.179115e+00   -5.56e+00    1.00e+00     1    4.50e-04
  30  6.103360e-01    1.03e-02    1.00e+01     1    4.26e-04
  31  5.673234e+00   -5.06e+00    1.00e+00     1    3.80e-04
  31  6.005390e-01    9.80e-03    1.00e+01     1    3.82e-04
  32  5.222804e+00   -4.62e+00    1.00e+00     1    3.73e-04
  32  5.912123e-01    9.33e-03    1.00e+01     1    3.73e-04
  33  4.820507e+00   -4.23e+00    1.00e+00     1    3.67e-04
  33  5.823195e-01    8.89e-03    1.00e+01     1    3.72e-04
  34  4.460151e+00   -3.88e+00    1.00e+00     1    3.66e-04
  34  5.738283e-01    8.49e-03    1.00e+01     1    3.71e-04
  35  4.136471e+00   -3.56e+00    1.00e+00     1    3.65e-04
  35  5.657095e-01    8.12e-03    1.00e+01     1    3.47e-04
  36  3.844970e+00   -3.28e+00    1.00e+00     1    3.41e-04
  36  5.579370e-01    7.77e-03    1.00e+01     1    3.46e-04
  37  3.581792e+00   -3.02e+00    1.00e+00     1    3.41e-04
  37  5.504872e-01    7.45e-03    1.00e+01     1    3.47e-04
  38  3.343618e+00   -2.79e+00    1.00e+00     1    3.41e-04
  38  5.433386e-01    7.15e-03    1.00e+01     1    3.46e-04
  39  3.127581e+00   -2.58e+00    1.00e+00     1    3.41e-04
  39  5.364718e-01    6.87e-03    1.00e+01     1    3.46e-04
  40  2.931194e+00   -2.39e+00    1.00e+00     1    3.41e-04
  40  5.298691e-01    6.60e-03    1.00e+01     1    3.46e-04
  41  2.752297e+00   -2.22e+00    1.00e+00     1    3.41e-04
  41  5.235142e-01    6.35e-03    1.00e+01     1    3.48e-04
  42  2.589006e+00   -2.07e+00    1.00e+00     1    3.41e-04
  42  5.173924e-01    6.12e-03    1.00e+01     1    3.45e-04
  43  2.439672e+00   -1.92e+00    1.00e+00     1    3.41e-04
  43  5.114899e-01    5.90e-03    1.00e+01     1    4.18e-04
  44  2.302849e+00   -1.79e+00    1.00e+00     1    3.75e-04
  44  5.057943e-01    5.70e-03    1.00e+01     1    3.67e-04
  45  2.177265e+00   -1.67e+00    1.00e+00     1    3.48e-04
  45  5.002939e-01    5.50e-03    1.00e+01     1    3.27e-04
  46  2.061800e+00   -1.56e+00    1.00e+00     1    3.23e-04
  46  4.949782e-01    5.32e-03    1.00e+01     1    3.26e-04
  47  1.955464e+00   -1.46e+00    1.00e+00     1    3.25e-04
  47  4.898373e-01    5.14e-03    1.00e+01     1    3.31e-04
  48  1.857378e+00   -1.37e+00    1.00e+00     1    3.18e-04
  48  4.848619e-01    4.98e-03    1.00e+01     1    3.22e-04
  49  1.766764e+00   -1.28e+00    1.00e+00     1    3.18e-04
  49  4.800436e-01    4.82e-03    1.00e+01     1    3.26e-04
  50  1.682928e+00   -1.20e+00    1.00e+00     1    3.21e-04
  50  4.753746e-01    4.67e-03    1.00e+01     1    3.25e-04
  51  1.605253e+00   -1.13e+00    1.00e+00     1    3.27e-04
  51  4.708473e-01    4.53e-03    1.00e+01     1    3.24e-04
  52  1.533185e+00   -1.06e+00    1.00e+00     1    3.18e-04
  52  4.664550e-01    4.39e-03    1.00e+01     1    3.27e-04
  53  1.466231e+00   -1.00e+00    1.00e+00     1    3.18e-04
  53  4.621912e-01    4.26e-03    1.00e+01     1    3.22e-04
  54  1.403947e+00   -9.42e-01    1.00e+00     1    3.17e-04
  54  4.580500e-01    4.14e-03    1.00e+01     1    3.25e-04
  55  1.345935e+00   -8.88e-01    1.00e+00     1    3.19e-04
  55  4.540258e-01    4.02e-03    1.00e+01     1    3.25e-04
  56  1.291835e+00   -8.38e-01    1.00e+00     1    3.21e-04
  56  4.501132e-01    3.91e-03    1.00e+01     1    3.27e-04
  57  1.241324e+00   -7.91e-01    1.00e+00     1    3.17e-04
  57  4.463073e-01    3.81e-03    1.00e+01     1    3.22e-04
  58  1.194109e+00   -7.48e-01    1.00e+00     1    3.16e-04
  58  4.426036e-01    3.70e-03    1.00e+01     1    3.21e-04
  59  1.149927e+00   -7.07e-01    1.00e+00     1    3.15e-04
  59  4.389976e-01    3.61e-03    1.00e+01     1    3.81e-04
  60  1.108537e+00   -6.70e-01    1.00e+00     1    3.39e-04
  60  4.354852e-01    3.51e-03    1.00e+01     1    3.35e-04
  61  1.069721e+00   -6.34e-01    1.00e+00     1    3.22e-04
  61  4.320626e-01    3.42e-03    1.00e+01     1    3.26e-04
  62  1.033283e+00   -6.01e-01    1.00e+00     1    3.18e-04
  62  4.287261e-01    3.34e-03    1.00e+01     1    3.23e-04
  63  9.990427e-01   -5.70e-01    1.00e+00     1    3.17e-04
  63  4.254723e-01    3.25e-03    1.00e+01     1    3.23e-04
  64  9.668352e-01   -5.41e-01    1.00e+00     1    3.17e-04
  64  4.222980e-01    3.17e-03    1.00e+01     1    3.23e-04
  65  9.365113e-01   -5.14e-01    1.00e+00     1    3.17e-04
  65  4.192000e-01    3.10e-03    1.00e+01     1    3.21e-04
  66  9.079340e-01   -4.89e-01    1.00e+00     1    3.16e-04
  66  4.161755e-01    3.02e-03    1.00e+01     1    3.15e-04
  67  8.809783e-01   -4.65e-01    1.00e+00     1    3.05e-04
  67  4.132217e-01    2.95e-03    1.00e+01     1    3.15e-04
  68  8.555294e-01   -4.42e-01    1.00e+00     1    3.10e-04
  68  4.103360e-01    2.89e-03    1.00e+01     1    3.14e-04
  69  8.314823e-01   -4.21e-01    1.00e+00     1    3.12e-04
  69  4.075159e-01    2.82e-03    1.00e+01     1    3.15e-04
  70  8.087402e-01   -4.01e-01    1.00e+00     1    3.15e-04
  70  4.047591e-01    2.76e-03    1.00e+01     1    3.22e-04
  71  7.872145e-01   -3.82e-01    1.00e+00     1    3.10e-04
  71  4.020633e-01    2.70e-03    1.00e+01     1    3.53e-04
  72  7.668235e-01   -3.65e-01    1.00e+00     1    5.22e-04
  72  3.994265e-01    2.64e-03    1.00e+01     1    3.65e-04
  73  7.474918e-01   -3.48e-01    1.00e+00     1    3.53e-04
  73  3.968466e-01    2.58e-03    1.00e+01     1    3.58e-04
  74  7.291502e-01   -3.32e-01    1.00e+00     1    3.51e-04
  74  3.943217e-01    2.52e-03    1.00e+01     1    3.63e-04
  75  7.117345e-01   -3.17e-01    1.00e+00     1    3.42e-04
  75  3.918500e-01    2.47e-03    1.00e+01     1    4.23e-04
  76  6.951855e-01   -3.03e-01    1.00e+00     1    3.65e-04
  76  3.894298e-01    2.42e-03    1.00e+01     1    3.58e-04
  77  6.794485e-01   -2.90e-01    1.00e+00     1    3.35e-04
  77  3.870593e-01    2.37e-03    1.00e+01     1    3.34e-04
  78  6.644728e-01   -2.77e-01    1.00e+00     1    3.22e-04
  78  3.847371e-01    2.32e-03    1.00e+01     1    3.27e-04
  79  6.502115e-01   -2.65e-01    1.00e+00     1    3.20e-04
  79  3.824616e-01    2.28e-03    1.00e+01     1    3.23e-04
  80  6.366211e-01   -2.54e-01    1.00e+00     1    3.18e-04
  80  3.802314e-01    2.23e-03    1.00e+01     1    3.25e-04
  81  6.236611e-01   -2.43e-01    1.00e+00     1    3.19e-04
  81  3.780451e-01    2.19e-03    1.00e+01     1    3.23e-04
  82  6.112940e-01   -2.33e-01    1.00e+00     1    3.22e-04
  82  3.759015e-01    2.14e-03    1.00e+01     1    3.23e-04
  83  5.994849e-01   -2.24e-01    1.00e+00     1    3.17e-04
  83  3.737991e-01    2.10e-03    1.00e+01     1    3.38e-04
  84  5.882014e-01   -2.14e-01    1.00e+00     1    3.23e-04
  84  3.717369e-01    2.06e-03    1.00e+01     1    9.53e-04
  85  5.774133e-01   -2.06e-01    1.00e+00     1    7.46e-04
  85  3.697137e-01    2.02e-03    1.00e+01     1    1.21e-03
  86  5.670923e-01   -1.97e-01    1.00e+00     1    8.38e-04
  86  3.677285e-01    1.99e-03    1.00e+01     1    5.99e-04
  87  5.572123e-01   -1.89e-01    1.00e+00     1    6.46e-04
  87  3.657800e-01    1.95e-03    1.00e+01     1    4.21e-04
  88  5.477487e-01   -1.82e-01    1.00e+00     1    8.80e-04
  88  3.638674e-01    1.91e-03    1.00e+01     1    1.23e-03
  89  5.386786e-01   -1.75e-01    1.00e+00     1    1.57e-03
  89  3.619897e-01    1.88e-03    1.00e+01     1    1.21e-03
  90  5.299807e-01   -1.68e-01    1.00e+00     1    1.29e-03
  90  3.601460e-01    1.84e-03    1.00e+01     1    1.27e-03
  91  5.216350e-01   -1.61e-01    1.00e+00     1    1.02e-03
  91  3.583352e-01    1.81e-03    1.00e+01     1    9.18e-04
  92  5.136227e-01   -1.55e-01    1.00e+00     1    4.02e-04
  92  3.565567e-01    1.78e-03    1.00e+01     1    1.09e-03
  93  5.059265e-01   -1.49e-01    1.00e+00     1    8.53e-04
  93  3.548096e-01    1.75e-03    1.00e+01     1    3.82e-04
  94  4.985297e-01   -1.44e-01    1.00e+00     1    3.40e-04
  94  3.530930e-01    1.72e-03    1.00e+01     1    3.37e-04
  95  4.914172e-01   -1.38e-01    1.00e+00     1    3.29e-04
  95  3.514062e-01    1.69e-03    1.00e+01     1    3.32e-04
  96  4.845743e-01   -1.33e-01    1.00e+00     1    3.25e-04
  96  3.497486e-01    1.66e-03    1.00e+01     1    3.31e-04
  97  4.779877e-01   -1.28e-01    1.00e+00     1    3.27e-04
  97  3.481193e-01    1.63e-03    1.00e+01     1    1.01e-03
  98  4.716446e-01   -1.24e-01    1.00e+00     1    9.35e-04
  98  3.465177e-01    1.60e-03    1.00e+01     1    1.01e-03
  99  4.655329e-01   -1.19e-01    1.00e+00     1    8.77e-04
  99  3.449432e-01    1.57e-03    1.00e+01     1    3.71e-04
dimension: 140 x 110
final cost: 0.344925
constraint violation: 1.83161e-05
step 0:         1.72047 1.66433 1.74929 1.80278
step 1:         1.73566 1.69142 1.73257 1.77582
step 2:         1.75481 1.72449 1.71234 1.74298
step 3:         1.78202 1.77058 1.68508 1.69728
step 4:         1.82205 1.83838 1.64811 1.63017
step 5:         1.88088 1.9377  1.60078 1.53196
step 6:         1.96644 2.07749 1.54604 1.39393
step 7:         2.08881 2.26236 1.49081 1.21231
step 8:         2.25773 2.48968 1.44371 0.992925
step 9:         2.47769 2.75118 1.41294 0.754963
step 10:        2.74585 3.04131 1.41419 0.538566
constraint manifold:
building optimizer
optimize
Initial error: 9114.63, values: 10
iter      cost      cost_change    lambda  success iter_time
   0  7.112714e+01    9.04e+03    1.00e-05     1    1.30e-03
   1  2.504199e-01    7.09e+01    1.00e-06     1    1.08e-03
   2  2.348647e-01    1.56e-02    1.00e-07     1    1.54e-03
   3  2.335934e-01    1.27e-03    1.00e-08     1    7.99e-04
   4  2.335668e-01    2.67e-05    1.00e-09     1    7.71e-04
   5  2.335668e-01    3.38e-08    1.00e-10     1    5.61e-04
dimension: 86 x 60
final cost: 0.233567
constraint violation: 1.3047e-23
step 0:         1.72047 1.66433 1.74929 1.80278
step 1:         1.81659 1.8085  1.71131 1.67912
step 2:         1.90973 1.95714 1.67058 1.55969
step 3:         2.00494 2.10319 1.63163 1.43812
step 4:         2.10308 2.2458  1.59504 1.31409
step 5:         2.20451 2.3847  1.56093 1.18781
step 6:         2.3093  2.51985 1.52917 1.05959
step 7:         2.4173  2.6514  1.49952 0.929808
step 8:         2.52806 2.77979 1.47155 0.798834
step 9:         2.64053 2.90618 1.44453 0.667179
step 10:        2.74588 3.04135 1.4142  0.538539
Timing results:
-Total: 0 CPU (0 times, 0 wall, 0.11 children, min: 0 max: 0)
|   -dynamic factor graph: 0.1 CPU (1 times, 0.108199 wall, 0.1 children, min: 0.1 max: 0.1)
|   -constraint manifold: 0.01 CPU (1 times, 0.007992 wall, 0.01 children, min: 0.01 max: 0.01)
[100%] Built target gerry01_cablerobot_manifold.run
```