### PR TITLE
ContactPoseFactor for flat foot constraint

### DIFF
--- a/gtdynamics/factors/ContactPointFactor.h
+++ b/gtdynamics/factors/ContactPointFactor.h
@@ -133,29 +133,29 @@ class ContactPoseFactor
    * Constructor.
    *
    * @param link_pose_key Key for the CoM pose of the link in contact.
-   * @param point_key Key for the contact point in the environment.
+   * @param contact_pose_key Key for the contact point pose in the world/spatial frame.
    * @param cost_model Noise model associated with this factor.
    * @param contact_in_com Static transform from point of contact to link CoM.
    */
-  ContactPoseFactor(gtsam::Key link_pose_key, gtsam::Key point_key,
+  ContactPoseFactor(gtsam::Key link_pose_key, gtsam::Key contact_pose_key,
                     const gtsam::noiseModel::Base::shared_ptr &cost_model,
                     const gtsam::Pose3 &comTcontact)
-      : Base(cost_model, link_pose_key, point_key), comTcontact_(comTcontact) {}
+      : Base(cost_model, link_pose_key, contact_pose_key), comTcontact_(comTcontact) {}
 
   /**
    * Convenience constructor which uses PointOnLink.
    *
    * @param point_on_link PointOnLink object which encapsulates the link and its
    * contact point.
-   * @param point_key Key for the contact point in the environment.
+   * @param contact_pose_key Key for the contact point pose in the world/spatial frame.
    * @param cost_model Noise model associated with this factor.
    * @param t The time step at which to add the factor (default t=0).
    */
-  ContactPoseFactor(const PointOnLink &point_on_link, gtsam::Key point_key,
+  ContactPoseFactor(const PointOnLink &point_on_link, gtsam::Key contact_pose_key,
                     const gtsam::noiseModel::Base::shared_ptr &cost_model,
                     size_t t = 0)
       : ContactPoseFactor(
-            gtdynamics::PoseKey(point_on_link.link->id(), t), point_key,
+            gtdynamics::PoseKey(point_on_link.link->id(), t), contact_pose_key,
             cost_model,
             // Contact reference frame has same rotation as the link CoM
             gtsam::Pose3(gtsam::Rot3(), point_on_link.point)) {}

--- a/gtdynamics/factors/ContactPointFactor.h
+++ b/gtdynamics/factors/ContactPointFactor.h
@@ -112,4 +112,96 @@ class ContactPointFactor
   }
 };
 
+/**
+ * ContactPoseFactor is a two-way nonlinear factor which constrains a link pose
+ * and a reference frame defined at a point of contact P in the world/spatial
+ * frame.
+ *
+ * This factor is useful for implementing flat foot constraints.
+ */
+class ContactPoseFactor
+    : public gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Pose3> {
+ private:
+  using This = ContactPoseFactor;
+  using Base = gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Pose3>;
+
+  // The contact point reference frame in the link's CoM frame.
+  gtsam::Pose3 comTcontact_;
+
+ public:
+  /**
+   * Constructor.
+   *
+   * @param link_pose_key Key for the CoM pose of the link in contact.
+   * @param point_key Key for the contact point in the environment.
+   * @param cost_model Noise model associated with this factor.
+   * @param contact_in_com Static transform from point of contact to link CoM.
+   */
+  ContactPoseFactor(gtsam::Key link_pose_key, gtsam::Key point_key,
+                    const gtsam::noiseModel::Base::shared_ptr &cost_model,
+                    const gtsam::Pose3 &comTcontact)
+      : Base(cost_model, link_pose_key, point_key), comTcontact_(comTcontact) {}
+
+  /**
+   * Convenience constructor which uses PointOnLink.
+   *
+   * @param point_on_link PointOnLink object which encapsulates the link and its
+   * contact point.
+   * @param point_key Key for the contact point in the environment.
+   * @param cost_model Noise model associated with this factor.
+   * @param t The time step at which to add the factor (default t=0).
+   */
+  ContactPoseFactor(const PointOnLink &point_on_link, gtsam::Key point_key,
+                    const gtsam::noiseModel::Base::shared_ptr &cost_model,
+                    size_t t = 0)
+      : ContactPoseFactor(
+            gtdynamics::PoseKey(point_on_link.link->id(), t), point_key,
+            cost_model,
+            // Contact reference frame has same rotation as the link CoM
+            gtsam::Pose3(gtsam::Rot3(), point_on_link.point)) {}
+
+  virtual ~ContactPoseFactor() {}
+
+  /**
+   * Evaluate error.
+   * @param wTl The link's COM pose in the world frame.
+   * @param wTcontact The environment contact point frame in the world frame.
+   */
+  gtsam::Vector evaluateError(
+      const gtsam::Pose3 &wTl, const gtsam::Pose3 &wTcontact,
+      boost::optional<gtsam::Matrix &> H_link = boost::none,
+      boost::optional<gtsam::Matrix &> H_contact = boost::none) const override {
+    gtsam::Pose3 measured_wTcontact = wTl.compose(comTcontact_, H_link);
+    gtsam::Matrix6 H1, H2;
+    gtsam::Vector error =
+        measured_wTcontact.localCoordinates(wTcontact, H1, H2);
+    if (H_link) *H_link = H1 * (*H_link);
+    if (H_contact) *H_contact = H2;
+    return error;
+  }
+
+  //// @return a deep copy of this factor
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
+    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+        gtsam::NonlinearFactor::shared_ptr(new This(*this)));
+  }
+
+  /// print contents
+  void print(const std::string &s = "",
+             const gtsam::KeyFormatter &keyFormatter =
+                 gtsam::DefaultKeyFormatter) const override {
+    std::cout << (s.empty() ? "" : s + " ") << "ContactPoseFactor" << std::endl;
+    Base::print("", keyFormatter);
+  }
+
+ private:
+  /// Serialization function
+  friend class boost::serialization::access;
+  template <class ARCHIVE>
+  void serialize(ARCHIVE &ar, const unsigned int version) {  // NOLINT
+    ar &boost::serialization::make_nvp(
+        "NonlinearEquality2", boost::serialization::base_object<Base>(*this));
+  }
+};
+
 }  // namespace gtdynamics

--- a/tests/testContactPointFactor.cpp
+++ b/tests/testContactPointFactor.cpp
@@ -30,7 +30,8 @@ using namespace gtdynamics;
 using namespace gtsam;
 using gtsam::assert_equal;
 
-auto kModel = noiseModel::Isotropic::Sigma(3, 0.1);
+auto kPointModel = noiseModel::Isotropic::Sigma(3, 0.1);
+auto kPoseModel = noiseModel::Isotropic::Sigma(6, 0.1);
 
 auto robot = simple_rr::getRobot();
 
@@ -38,10 +39,10 @@ TEST(ContactPointFactor, Constructor) {
   Key link_pose_key = gtdynamics::PoseKey(0, 0),
       point_key = gtdynamics::PoseKey(1, 0);
   Point3 lPc(0, 0, 1);
-  ContactPointFactor(link_pose_key, point_key, kModel, lPc);
+  ContactPointFactor(link_pose_key, point_key, kPointModel, lPc);
 
   PointOnLink point_on_link(robot.links()[0], lPc);
-  ContactPointFactor(point_on_link, point_key, kModel, 10);
+  ContactPointFactor(point_on_link, point_key, kPointModel, 10);
 }
 
 TEST(ContactPointFactor, Error) {
@@ -51,7 +52,7 @@ TEST(ContactPointFactor, Error) {
   Key point_key = gtdynamics::PoseKey(1, 0);
   Point3 wPc(0, 0, 1);
 
-  ContactPointFactor factor(point_on_link, point_key, kModel, 0);
+  ContactPointFactor factor(point_on_link, point_key, kPointModel, 0);
 
   Vector error = factor.evaluateError(point_on_link.link->bMcom(), wPc);
   EXPECT(assert_equal(Vector3(0, 0, -0.1), error, 1e-9));
@@ -69,7 +70,7 @@ TEST(ContactPointFactor, Jacobians) {
   Key point_key = gtdynamics::PoseKey(1, 0);
   Point3 wPc(0, 0, 1);
 
-  ContactPointFactor factor(point_on_link, point_key, kModel, 0);
+  ContactPointFactor factor(point_on_link, point_key, kPointModel, 0);
 
   Values values;
   InsertPose(&values, end_link->id(), 0, point_on_link.link->bMcom());
@@ -84,10 +85,10 @@ TEST(ContactPoseFactor, Constructor) {
       point_key = gtdynamics::PoseKey(1, 0);
   Point3 wPc(0, 0, 1);
   Pose3 linkTcontact(Rot3(), wPc);
-  ContactPoseFactor(link_pose_key, point_key, kModel, linkTcontact);
+  ContactPoseFactor(link_pose_key, point_key, kPoseModel, linkTcontact);
 
   PointOnLink point_on_link(robot.links()[0], wPc);
-  ContactPoseFactor(point_on_link, point_key, kModel, 10);
+  ContactPoseFactor(point_on_link, point_key, kPoseModel, 10);
 }
 
 TEST(ContactPoseFactor, Error) {
@@ -99,14 +100,14 @@ TEST(ContactPoseFactor, Error) {
 
   Pose3 wTcontact(Rot3(), wPc);
 
-  ContactPoseFactor factor(point_on_link, point_key, kModel, 0);
+  ContactPoseFactor factor(point_on_link, point_key, kPoseModel, 0);
 
   Vector error = factor.evaluateError(point_on_link.link->bMcom(), wTcontact);
   Vector6 expected;
   expected << 0, 0, 0, 0, 0, -0.1;
   EXPECT(assert_equal(expected, error, 1e-9));
 
-  // Check error when contact point is not consistent
+  // Check error when contact point is translated
   Point3 wPc2(1, 1, 2);
   Pose3 wTcontact2(Rot3(), wPc2);
   error = factor.evaluateError(point_on_link.link->bMcom(), wTcontact2);
@@ -114,25 +115,37 @@ TEST(ContactPoseFactor, Error) {
   expected2 << 0, 0, 0, 1.0, 1.0, 0.9;
   EXPECT(assert_equal(expected2, error, 1e-9));
 
-  //TODO(Varun) Add tests for when there is deviation in rotation.
+  // Check error when contact point is rotated
+  Pose3 wTcontact3(Rot3::RzRyRx(0, 2, 0), wPc);
+  error = factor.evaluateError(point_on_link.link->bMcom(), wTcontact3);
+  // regression
+  Vector6 expected3;
+  expected3 << 0, 2, -0, 0.1, 0, -0.0642092616;
+  EXPECT(assert_equal(expected3, error, 1e-9));
 }
 
-// TEST(ContactPoseFactor, Jacobians) {
-//   auto end_link = robot.links()[0];
-//   PointOnLink point_on_link{end_link, Point3(0, 0, 1)};
+TEST(ContactPoseFactor, Jacobians) {
+  auto end_link = robot.links()[0];
+  Point3 wPc(0, 0, 1);
+  PointOnLink point_on_link{end_link, wPc};
 
-//   Key point_key = gtdynamics::PoseKey(1, 0);
-//   Point3 wPc(0, 0, 1);
+  Key point_key = gtdynamics::PoseKey(1, 0);
+  Pose3 wTc(Rot3(), wPc);
 
-//   ContactPoseFactor factor(point_on_link, point_key, kModel, 0);
+  ContactPoseFactor factor(point_on_link, point_key, kPoseModel, 0);
 
-//   Values values;
-//   InsertPose(&values, end_link->id(), 0, point_on_link.link->bMcom());
-//   values.insert<Point3>(point_key, wPc);
+  Values values;
+  InsertPose(&values, end_link->id(), 0, point_on_link.link->bMcom());
+  values.insert<Pose3>(point_key, wTc);
 
-//   // Check Jacobians
-//   EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
-// }
+  // Check Jacobians
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
+
+  // Check Jacobians with non-identity rotation
+  Pose3 wTc2(Rot3::RzRyRx(1, 2, 3), wPc);
+  values.update<Pose3>(point_key, wTc2);
+  EXPECT_CORRECT_FACTOR_JACOBIANS(factor, values, 1e-7, 1e-5);
+}
 
 int main() {
   TestResult tr;


### PR DESCRIPTION
This PR adds a new `ContactPoseFactor` which constraints a link to a reference frame (aka `Pose3`), in contrast to `ContactPointFactor` which constrains to a `Point3`. This is very useful for humanoids for both feet as well as grasping contact.