### PR TITLE
Use homebrew to install GTSAM

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -46,12 +46,6 @@ jobs:
           brew tap osrf/simulation
           brew install sdformat12
 
-          # Install CppUnitLite.
-          git clone https://github.com/borglab/CppUnitLite.git
-          cd CppUnitLite && mkdir build && cd $_
-          cmake .. && sudo make -j4 install
-          cd ../../
-
       - name: GTSAM
         run: brew install --HEAD borglab/core/gtsam
 
@@ -63,7 +57,7 @@ jobs:
 
       - name: Configure
         run: |
-          cmake -DGTDYNAMICS_BUILD_PYTHON=OFF -DGTDYNAMICS_BUILD_CABLE_ROBOT=ON -DGTDYNAMICS_BUILD_JUMPING_ROBOT=ON ..
+          cmake -DGTDYNAMICS_BUILD_PYTHON=OFF -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF -DGTDYNAMICS_BUILD_CABLE_ROBOT=ON -DGTDYNAMICS_BUILD_JUMPING_ROBOT=ON ..
         working-directory: ./build
 
       - name: Build

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -47,13 +47,7 @@ jobs:
           brew install sdformat12
 
       - name: GTSAM
-        run: |
-          git clone https://github.com/borglab/gtsam.git
-          cd gtsam
-          mkdir build && cd build
-          cmake -D GTSAM_BUILD_EXAMPLES_ALWAYS=OFF ..
-          make -j$(sysctl -n hw.physicalcpu) install
-          cd ../../ # go back to home directory
+        run: brew install --HEAD borglab/core/gtsam
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -46,6 +46,12 @@ jobs:
           brew tap osrf/simulation
           brew install sdformat12
 
+          # Install CppUnitLite.
+          git clone https://github.com/borglab/CppUnitLite.git
+          cd CppUnitLite && mkdir build && cd $_
+          cmake .. && sudo make -j4 install
+          cd ../../
+
       - name: GTSAM
         run: brew install --HEAD borglab/core/gtsam
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -45,9 +45,10 @@ jobs:
           brew install boost
           brew tap osrf/simulation
           brew install sdformat12
+          brew tap borglab/core
 
       - name: GTSAM
-        run: brew install --HEAD borglab/core/gtsam
+        run: brew install --HEAD gtsam@latest
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Use homebrew so that GTSAM installation is potentially faster. This should also allow us to use pre-built binaries in the future.