### PR TITLE
Optional parent and child link keys for `poseConstraint`

### DIFF
--- a/gtdynamics/dynamics/DynamicsGraph.cpp
+++ b/gtdynamics/dynamics/DynamicsGraph.cpp
@@ -26,9 +26,8 @@
 #include <gtsam/nonlinear/expressions.h>
 #include <gtsam/slam/PriorFactor.h>
 
-#include <boost/format.hpp>
-
 #include <algorithm>
+#include <boost/format.hpp>
 #include <iostream>
 #include <map>
 #include <set>
@@ -203,9 +202,9 @@ gtsam::NonlinearFactorGraph DynamicsGraph::qFactors(
 
   // TODO(frank): call Kinematics::graph<Slice> instead
   for (auto &&joint : robot.joints()) {
-    graph.add(PoseFactor(
-        PoseKey(joint->parent()->id(), k), PoseKey(joint->child()->id(), k),
-        JointAngleKey(joint->id(), k), opt_.p_cost_model, joint));
+    graph.add(PoseFactor(PoseKey(joint->parent()->id(), k),
+                         PoseKey(joint->child()->id(), k), opt_.p_cost_model,
+                         joint));
   }
 
   // TODO(frank): whoever write this should clean up this mess.

--- a/gtdynamics/dynamics/DynamicsGraph.cpp
+++ b/gtdynamics/dynamics/DynamicsGraph.cpp
@@ -202,9 +202,9 @@ gtsam::NonlinearFactorGraph DynamicsGraph::qFactors(
 
   // TODO(frank): call Kinematics::graph<Slice> instead
   for (auto &&joint : robot.joints()) {
-    graph.add(PoseFactor(PoseKey(joint->parent()->id(), k),
-                         PoseKey(joint->child()->id(), k), opt_.p_cost_model,
-                         joint));
+    graph.add(PoseFactor(
+        PoseKey(joint->parent()->id(), k), PoseKey(joint->child()->id(), k),
+        JointAngleKey(joint->id(), k), opt_.p_cost_model, joint));
   }
 
   // TODO(frank): whoever write this should clean up this mess.

--- a/gtdynamics/factors/PoseFactor.h
+++ b/gtdynamics/factors/PoseFactor.h
@@ -59,17 +59,16 @@ inline gtsam::NoiseModelFactor::shared_ptr PoseFactor(
  *
  * @param wTp_key Key for parent link's CoM pose in world frame.
  * @param wTc_key Key for child link's CoM pose in world frame.
- * @param q_key Key for joint value.
  * @param cost_model The noise model for this factor.
  * @param joint The joint connecting the two poses
  */
 inline gtsam::NoiseModelFactor::shared_ptr PoseFactor(
-    DynamicsSymbol wTp_key, DynamicsSymbol wTc_key, DynamicsSymbol q_key,
+    DynamicsSymbol wTp_key, DynamicsSymbol wTc_key,
     const gtsam::noiseModel::Base::shared_ptr &cost_model,
     JointConstSharedPtr joint) {
   return boost::make_shared<gtsam::ExpressionFactor<gtsam::Vector6>>(
       cost_model, gtsam::Vector6::Zero(),
-      joint->poseConstraint(wTp_key.time()));
+      joint->poseConstraint(wTp_key.time(), wTp_key, wTc_key));
 }
 
 }  // namespace gtdynamics

--- a/gtdynamics/factors/PoseFactor.h
+++ b/gtdynamics/factors/PoseFactor.h
@@ -63,7 +63,7 @@ inline gtsam::NoiseModelFactor::shared_ptr PoseFactor(
  * @param joint The joint connecting the two poses
  */
 inline gtsam::NoiseModelFactor::shared_ptr PoseFactor(
-    DynamicsSymbol wTp_key, DynamicsSymbol wTc_key,
+    DynamicsSymbol wTp_key, DynamicsSymbol wTc_key, DynamicsSymbol q_key,
     const gtsam::noiseModel::Base::shared_ptr &cost_model,
     JointConstSharedPtr joint) {
   return boost::make_shared<gtsam::ExpressionFactor<gtsam::Vector6>>(

--- a/gtdynamics/factors/PoseFactor.h
+++ b/gtdynamics/factors/PoseFactor.h
@@ -68,7 +68,7 @@ inline gtsam::NoiseModelFactor::shared_ptr PoseFactor(
     JointConstSharedPtr joint) {
   return boost::make_shared<gtsam::ExpressionFactor<gtsam::Vector6>>(
       cost_model, gtsam::Vector6::Zero(),
-      joint->poseConstraint(wTp_key.time(), wTp_key, wTc_key));
+      joint->poseConstraint(wTp_key, wTc_key, q_key));
 }
 
 }  // namespace gtdynamics

--- a/gtdynamics/kinematics/KinematicsSlice.cpp
+++ b/gtdynamics/kinematics/KinematicsSlice.cpp
@@ -44,7 +44,7 @@ NonlinearFactorGraph Kinematics::graph<Slice>(const Slice& slice,
     const auto j = joint->id();
     graph.add(PoseFactor(PoseKey(joint->parent()->id(), slice.k),
                          PoseKey(joint->child()->id(), slice.k),
-                         p_.p_cost_model, joint));
+                         JointAngleKey(j, slice.k), p_.p_cost_model, joint));
   }
 
   return graph;

--- a/gtdynamics/kinematics/KinematicsSlice.cpp
+++ b/gtdynamics/kinematics/KinematicsSlice.cpp
@@ -44,7 +44,7 @@ NonlinearFactorGraph Kinematics::graph<Slice>(const Slice& slice,
     const auto j = joint->id();
     graph.add(PoseFactor(PoseKey(joint->parent()->id(), slice.k),
                          PoseKey(joint->child()->id(), slice.k),
-                         JointAngleKey(j, slice.k), p_.p_cost_model, joint));
+                         p_.p_cost_model, joint));
   }
 
   return graph;

--- a/gtdynamics/universal_robot/Joint.cpp
+++ b/gtdynamics/universal_robot/Joint.cpp
@@ -275,21 +275,21 @@ gtsam::Expression<typename gtsam::traits<T>::TangentVector> logmap(
 }
 
 /* ************************************************************************* */
-gtsam::Vector6_ Joint::poseConstraint(
-    uint64_t t, const boost::optional<DynamicsSymbol> &wTp_key,
-    const boost::optional<DynamicsSymbol> &wTc_key) const {
+gtsam::Vector6_ Joint::poseConstraint(uint64_t t) const {
+  return poseConstraint(PoseKey(parent()->id(), t), PoseKey(child()->id(), t),
+                        JointAngleKey(id(), t));
+}
+
+/* ************************************************************************* */
+gtsam::Vector6_ Joint::poseConstraint(const DynamicsSymbol &wTp_key,
+                                      const DynamicsSymbol &wTc_key,
+                                      const DynamicsSymbol &q_key) const {
   using gtsam::Pose3_;
 
   // Get an expression for parent pose.
-  Pose3_ wTp(PoseKey(parent()->id(), t));
-  Pose3_ wTc(PoseKey(child()->id(), t));
-  if (wTp_key) {
-    wTp = Pose3_(wTp_key->key());
-  }
-  if (wTc_key) {
-    wTc = Pose3_(wTc_key->key());
-  }
-  gtsam::Double_ q(JointAngleKey(id(), t));
+  Pose3_ wTp(wTp_key);
+  Pose3_ wTc(wTc_key);
+  gtsam::Double_ q(q_key);
 
   // Compute the expected pose of the child link.
   Pose3_ pTc(std::bind(&Joint::parentTchild, this, std::placeholders::_1,

--- a/gtdynamics/universal_robot/Joint.cpp
+++ b/gtdynamics/universal_robot/Joint.cpp
@@ -275,12 +275,20 @@ gtsam::Expression<typename gtsam::traits<T>::TangentVector> logmap(
 }
 
 /* ************************************************************************* */
-gtsam::Vector6_ Joint::poseConstraint(uint64_t t) const {
+gtsam::Vector6_ Joint::poseConstraint(
+    uint64_t t, const boost::optional<gtsam::Key> &wTp_key,
+    const boost::optional<gtsam::Key> &wTc_key) const {
   using gtsam::Pose3_;
 
   // Get an expression for parent pose.
   Pose3_ wTp(PoseKey(parent()->id(), t));
   Pose3_ wTc(PoseKey(child()->id(), t));
+  if (wTp_key) {
+    wTp = Pose3_(*wTp_key);
+  }
+  if (wTc_key) {
+    wTc = Pose3_(*wTc_key);
+  }
   gtsam::Double_ q(JointAngleKey(id(), t));
 
   // Compute the expected pose of the child link.

--- a/gtdynamics/universal_robot/Joint.cpp
+++ b/gtdynamics/universal_robot/Joint.cpp
@@ -276,18 +276,18 @@ gtsam::Expression<typename gtsam::traits<T>::TangentVector> logmap(
 
 /* ************************************************************************* */
 gtsam::Vector6_ Joint::poseConstraint(
-    uint64_t t, const boost::optional<gtsam::Key> &wTp_key,
-    const boost::optional<gtsam::Key> &wTc_key) const {
+    uint64_t t, const boost::optional<DynamicsSymbol> &wTp_key,
+    const boost::optional<DynamicsSymbol> &wTc_key) const {
   using gtsam::Pose3_;
 
   // Get an expression for parent pose.
   Pose3_ wTp(PoseKey(parent()->id(), t));
   Pose3_ wTc(PoseKey(child()->id(), t));
   if (wTp_key) {
-    wTp = Pose3_(*wTp_key);
+    wTp = Pose3_(wTp_key->key());
   }
   if (wTc_key) {
-    wTc = Pose3_(*wTc_key);
+    wTc = Pose3_(wTc_key->key());
   }
   gtsam::Double_ q(JointAngleKey(id(), t));
 

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -416,9 +416,16 @@ class Joint : public boost::enable_shared_from_this<Joint> {
    * @brief Create expression that constraint the pose of two links imposed by
    * the joint angle.
    */
-  gtsam::Vector6_ poseConstraint(
-      uint64_t t = 0, const boost::optional<DynamicsSymbol> &wTp = boost::none,
-      const boost::optional<DynamicsSymbol> &wTc = boost::none) const;
+  gtsam::Vector6_ poseConstraint(uint64_t t = 0) const;
+
+  /**
+   * @brief Create expression that constraint the pose of two links imposed by
+   * the joint angle. Alternative version using custom keys.
+   * TODO(Varun) Need to do the same for all other constraints below
+   */
+  gtsam::Vector6_ poseConstraint(const DynamicsSymbol &wTp_key,
+                                 const DynamicsSymbol &wTc_key,
+                                 const DynamicsSymbol &q_key) const;
 
   /**
    * @brief Create expression that constraint the twist of two links imposed by

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -417,8 +417,8 @@ class Joint : public boost::enable_shared_from_this<Joint> {
    * the joint angle.
    */
   gtsam::Vector6_ poseConstraint(
-      uint64_t t = 0, const boost::optional<gtsam::Key> &wTp = boost::none,
-      const boost::optional<gtsam::Key> &wTc = boost::none) const;
+      uint64_t t = 0, const boost::optional<DynamicsSymbol> &wTp = boost::none,
+      const boost::optional<DynamicsSymbol> &wTc = boost::none) const;
 
   /**
    * @brief Create expression that constraint the twist of two links imposed by

--- a/gtdynamics/universal_robot/Joint.h
+++ b/gtdynamics/universal_robot/Joint.h
@@ -416,7 +416,9 @@ class Joint : public boost::enable_shared_from_this<Joint> {
    * @brief Create expression that constraint the pose of two links imposed by
    * the joint angle.
    */
-  gtsam::Vector6_ poseConstraint(uint64_t t = 0) const;
+  gtsam::Vector6_ poseConstraint(
+      uint64_t t = 0, const boost::optional<gtsam::Key> &wTp = boost::none,
+      const boost::optional<gtsam::Key> &wTc = boost::none) const;
 
   /**
    * @brief Create expression that constraint the twist of two links imposed by

--- a/tests/testPoseFactor.cpp
+++ b/tests/testPoseFactor.cpp
@@ -52,7 +52,7 @@ TEST(PoseFactor, error) {
   auto joint = make_joint(cMp, screw_axis);
 
   // Create factor
-  auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
+  auto factor = PoseFactor(example::wTp_key, example::wTc_key,
                            example::cost_model, joint);
 
   // call unwhitenedError
@@ -78,7 +78,7 @@ TEST(PoseFactor, breaking) {
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
   auto joint = make_joint(cMp, screw_axis);
-  auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
+  auto factor = PoseFactor(example::wTp_key, example::wTc_key,
                            example::cost_model, joint);
 
   // check prediction at zero joint angle
@@ -112,7 +112,7 @@ TEST(PoseFactor, breaking_rr) {
   Vector6 screw_axis = (Vector6() << 1, 0, 0, 0, -1, 0).finished();
   Pose3 cMp = j1->relativePoseOf(l1, 0.0);
   auto joint = make_joint(cMp, screw_axis);
-  auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
+  auto factor = PoseFactor(example::wTp_key, example::wTc_key,
                            example::cost_model, joint);
 
   // unwhitenedError
@@ -130,7 +130,7 @@ TEST(PoseFactor, nonzero_rest) {
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
   auto joint = make_joint(cMp, screw_axis);
-  auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
+  auto factor = PoseFactor(example::wTp_key, example::wTc_key,
                            example::cost_model, joint);
 
   double jointAngle;

--- a/tests/testPoseFactor.cpp
+++ b/tests/testPoseFactor.cpp
@@ -52,7 +52,7 @@ TEST(PoseFactor, error) {
   auto joint = make_joint(cMp, screw_axis);
 
   // Create factor
-  auto factor = PoseFactor(example::wTp_key, example::wTc_key,
+  auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
                            example::cost_model, joint);
 
   // call unwhitenedError
@@ -78,7 +78,7 @@ TEST(PoseFactor, breaking) {
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
   auto joint = make_joint(cMp, screw_axis);
-  auto factor = PoseFactor(example::wTp_key, example::wTc_key,
+  auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
                            example::cost_model, joint);
 
   // check prediction at zero joint angle
@@ -112,7 +112,7 @@ TEST(PoseFactor, breaking_rr) {
   Vector6 screw_axis = (Vector6() << 1, 0, 0, 0, -1, 0).finished();
   Pose3 cMp = j1->relativePoseOf(l1, 0.0);
   auto joint = make_joint(cMp, screw_axis);
-  auto factor = PoseFactor(example::wTp_key, example::wTc_key,
+  auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
                            example::cost_model, joint);
 
   // unwhitenedError
@@ -130,7 +130,7 @@ TEST(PoseFactor, nonzero_rest) {
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
   auto joint = make_joint(cMp, screw_axis);
-  auto factor = PoseFactor(example::wTp_key, example::wTc_key,
+  auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
                            example::cost_model, joint);
 
   double jointAngle;

--- a/tests/testRobot.cpp
+++ b/tests/testRobot.cpp
@@ -103,8 +103,8 @@ TEST(Robot, ForwardKinematics) {
   Values results = robot.forwardKinematics(values);
 
   // The CoM frames at rest are:
-  Pose3 T_wl1_rest(Rot3::identity(), Point3(0, 0, 1));
-  Pose3 T_wl2_rest(Rot3::identity(), Point3(0, 0, 3));
+  Pose3 T_wl1_rest(Rot3::Identity(), Point3(0, 0, 1));
+  Pose3 T_wl2_rest(Rot3::Identity(), Point3(0, 0, 3));
   // At rest, all the twists are 0:
   Vector6 V_l1_rest, V_l2_rest;
   V_l1_rest << 0, 0, 0, 0, 0, 0;
@@ -122,7 +122,7 @@ TEST(Robot, ForwardKinematics) {
 
   Values results2 = robot.forwardKinematics(values2);
 
-  Pose3 T_wl1_move(Rot3::identity(), Point3(0, 0, 1));  // link1 stays put
+  Pose3 T_wl1_move(Rot3::Identity(), Point3(0, 0, 1));  // link1 stays put
   // link2 is rotated by 90 degrees and now points along -Y axis.
   Pose3 T_wl2_move(Rot3::Rx(M_PI_2), Point3(0, -1, 2));
   Vector6 V_l1_move, V_l2_move;
@@ -163,10 +163,10 @@ TEST(Robot, ForwardKinematicsRPR) {
   robot = robot.fixLink("link_0");
   Values fk_results = robot.forwardKinematics(values);
 
-  Pose3 T_wl0_rest(Rot3::identity(), Point3(0, 0, 0.1));
-  Pose3 T_wl1_rest(Rot3::identity(), Point3(0, 0, 0.5));
-  Pose3 T_wl2_rest(Rot3::identity(), Point3(0, 0, 1.1));
-  Pose3 T_wl3_rest(Rot3::identity(), Point3(0, 0, 1.7));
+  Pose3 T_wl0_rest(Rot3::Identity(), Point3(0, 0, 0.1));
+  Pose3 T_wl1_rest(Rot3::Identity(), Point3(0, 0, 0.5));
+  Pose3 T_wl2_rest(Rot3::Identity(), Point3(0, 0, 1.1));
+  Pose3 T_wl3_rest(Rot3::Identity(), Point3(0, 0, 1.7));
   Vector6 V_l0_rest, V_l1_rest, V_l2_rest, V_l3_rest;
   V_l0_rest << 0, 0, 0, 0, 0, 0;
   V_l1_rest << 0, 0, 0, 0, 0, 0;
@@ -190,7 +190,7 @@ TEST(Robot, ForwardKinematicsRPR) {
 
   fk_results = robot.forwardKinematics(values2);
 
-  Pose3 T_wl0_move(Rot3::identity(), Point3(0, 0, 0.1));
+  Pose3 T_wl0_move(Rot3::Identity(), Point3(0, 0, 0.1));
   Pose3 T_wl1_move(Rot3::Ry(M_PI_2), Point3(0.3, 0, 0.2));
   Pose3 T_wl2_move(Rot3::Ry(M_PI_2), Point3(1.4, 0, 0.2));
   Pose3 T_wl3_move(Rot3::Ry(M_PI_2), Point3(2.0, 0, 0.2));

--- a/tests/testSdf.cpp
+++ b/tests/testSdf.cpp
@@ -344,7 +344,7 @@ TEST(Sdf, sdf_constructor_revolute) {
   EXPECT(assert_equal(screw_axis_j1_l1, j1->screwAxis(l1)));
 
   // Check transform from l0 com to l1 com at rest and at various angles.
-  Pose3 M_01(Rot3::identity(), Point3(0, 0, 0.4));
+  Pose3 M_01(Rot3::Identity(), Point3(0, 0, 0.4));
   Pose3 T_01_neg(Rot3::Rz(-M_PI / 2), Point3(0, 0, 0.4));
   Pose3 T_01_pos(Rot3::Rz(M_PI / 2), Point3(0, 0, 0.4));
 
@@ -372,7 +372,7 @@ TEST(Sdf, sdf_constructor_revolute) {
   EXPECT(assert_equal(screw_axis_j2_l2, j2->screwAxis(l2)));
 
   // Check transform from l1 com to l2 com at rest and at various angles.
-  Pose3 M_12(Rot3::identity(), Point3(0, 0, 0.6));
+  Pose3 M_12(Rot3::Identity(), Point3(0, 0, 0.6));
   Pose3 T_12_pi_2(Rot3::Ry(M_PI / 2), Point3(0.3, 0.0, 0.3));
   Pose3 T_12_pi_4(Rot3::Ry(M_PI / 4), Point3(0.2121, 0.0, 0.5121));
 
@@ -556,7 +556,7 @@ TEST(Sdf, sdf_constructor_screw) {
   EXPECT(assert_equal(screw_axis_j1_l1, j1->screwAxis(l1)));
 
   // Check transform from l0 com to l1 com at rest and at various angles.
-  Pose3 M_01(Rot3::identity(), Point3(0, 0, 0.4));
+  Pose3 M_01(Rot3::Identity(), Point3(0, 0, 0.4));
   Pose3 T_01_neg(Rot3::Rz(-M_PI / 2), Point3(0, 0, 0.4 - 0.125));
   Pose3 T_01_pos(Rot3::Rz(M_PI / 2), Point3(0, 0, 0.4 + 0.125));
 


### PR DESCRIPTION
This will allow us to specify custom keys as passed to the second constructor of `PoseFactor`.