### PR TITLE
Key Helpers return `gtsam::Key`

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -91,7 +91,7 @@ class MinTorqueFactor : gtsam::NonlinearFactor {
 #include <gtdynamics/factors/WrenchFactor.h>
 gtsam::NonlinearFactor* WrenchFactor(
     const gtsam::noiseModel::Base *cost_model, const gtdynamics::Link *link,
-    const std::vector<gtdynamics::DynamicsSymbol> wrench_keys, int t = 0,
+    const std::vector<gtsam::Key> wrench_keys, int t = 0,
     const boost::optional<gtsam::Vector3> &gravity);
 
 #include <gtdynamics/factors/CollocationFactors.h>
@@ -655,17 +655,17 @@ class DynamicsSymbol {
   bool equals(const gtdynamics::DynamicsSymbol& expected, double tol);
 };
 
-gtdynamics::DynamicsSymbol JointAngleKey(int j, int t=0);
-gtdynamics::DynamicsSymbol JointVelKey(int j, int t=0);
-gtdynamics::DynamicsSymbol JointAccelKey(int j, int t=0);
-gtdynamics::DynamicsSymbol TorqueKey(int j, int t=0);
-gtdynamics::DynamicsSymbol TwistKey(int i, int t=0);
-gtdynamics::DynamicsSymbol TwistAccelKey(int i, int t=0);
-gtdynamics::DynamicsSymbol WrenchKey(int i, int j, int t=0);
-gtdynamics::DynamicsSymbol PoseKey(int i, int t=0);
-gtdynamics::DynamicsSymbol ContactWrenchKey(int i, int k, int t=0);
-gtdynamics::DynamicsSymbol PhaseKey(int k);
-gtdynamics::DynamicsSymbol TimeKey(int t);
+gtsam::Key JointAngleKey(int j, int t=0);
+gtsam::Key JointVelKey(int j, int t=0);
+gtsam::Key JointAccelKey(int j, int t=0);
+gtsam::Key TorqueKey(int j, int t=0);
+gtsam::Key TwistKey(int i, int t=0);
+gtsam::Key TwistAccelKey(int i, int t=0);
+gtsam::Key WrenchKey(int i, int j, int t=0);
+gtsam::Key PoseKey(int i, int t=0);
+gtsam::Key ContactWrenchKey(int i, int k, int t=0);
+gtsam::Key PhaseKey(int k);
+gtsam::Key TimeKey(int t);
 
 ///////////////////// Key Methods /////////////////////
 void InsertJointAngle(gtsam::Values@ values, int j, int t, double value);

--- a/gtdynamics/cablerobot/factors/PriorFactor.h
+++ b/gtdynamics/cablerobot/factors/PriorFactor.h
@@ -8,10 +8,8 @@
 
 #pragma once
 
-#include <gtdynamics/utils/DynamicsSymbol.h>
-
-#include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/base/Testable.h>
+#include <gtsam/nonlinear/PriorFactor.h>
 
 #include <string>
 

--- a/gtdynamics/cablerobot/src/cdpr_planar.py
+++ b/gtdynamics/cablerobot/src/cdpr_planar.py
@@ -110,16 +110,16 @@ class Cdpr:
             for ji in range(4):
                 kfg.push_back(
                     gtd.CableLengthFactor(
-                        gtd.JointAngleKey(ji, k).key(),
-                        gtd.PoseKey(self.ee_id(), k).key(),  #
+                        gtd.JointAngleKey(ji, k),
+                        gtd.PoseKey(self.ee_id(), k),  #
                         self.costmodel_l,
                         self.params.a_locs[ji],
                         self.params.b_locs[ji]))
                 kfg.push_back(
                     gtd.CableVelocityFactor(
-                        gtd.JointVelKey(ji, k).key(),
-                        gtd.PoseKey(self.ee_id(), k).key(),
-                        gtd.TwistKey(self.ee_id(), k).key(),  #
+                        gtd.JointVelKey(ji, k),
+                        gtd.PoseKey(self.ee_id(), k),
+                        gtd.TwistKey(self.ee_id(), k),  #
                         self.costmodel_ldot,
                         self.params.a_locs[ji],
                         self.params.b_locs[ji]))
@@ -129,7 +129,7 @@ class Cdpr:
             kfg.push_back(
                 gtsam.LinearContainerFactor(
                     gtsam.JacobianFactor(
-                        gtd.PoseKey(self.ee_id(), k).key(),
+                        gtd.PoseKey(self.ee_id(), k),
                         np.array([[1, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0],
                                   [0, 0, 0, 0, 1, 0.]]), np.zeros(3),
                         self.costmodel_planar_pose), zeroT))
@@ -138,7 +138,7 @@ class Cdpr:
             kfg.push_back(
                 gtsam.LinearContainerFactor(
                     gtsam.JacobianFactor(
-                        gtd.TwistKey(self.ee_id(), k).key(),
+                        gtd.TwistKey(self.ee_id(), k),
                         np.array([[1, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0],
                                   [0, 0, 0, 0, 1, 0.]]), np.zeros(3),
                         self.costmodel_planar_twist), zeroV))
@@ -170,12 +170,12 @@ class Cdpr:
                 ], k, self.params.gravity))
             for ji in range(4):
                 dfg.push_back(
-                    gtd.CableTensionFactor(
-                        gtd.TorqueKey(ji, k).key(),
-                        gtd.PoseKey(self.ee_id(), k).key(),
-                        gtd.WrenchKey(self.ee_id(), ji,
-                                      k).key(), self.costmodel_torque,
-                        self.params.a_locs[ji], self.params.b_locs[ji]))
+                    gtd.CableTensionFactor(gtd.TorqueKey(ji, k),
+                                           gtd.PoseKey(self.ee_id(), k),
+                                           gtd.WrenchKey(self.ee_id(), ji, k),
+                                           self.costmodel_torque,
+                                           self.params.a_locs[ji],
+                                           self.params.b_locs[ji]))
         return dfg
 
     def collocation_factors(self, ks=[], dt=0.01):
@@ -195,15 +195,15 @@ class Cdpr:
         for k in ks:
             dfg.push_back(
                 gtd.EulerPoseCollocationFactor(
-                    gtd.PoseKey(self.ee_id(), k).key(),
-                    gtd.PoseKey(self.ee_id(), k + 1).key(),
-                    gtd.TwistKey(self.ee_id(), k).key(), 0,
+                    gtd.PoseKey(self.ee_id(), k),
+                    gtd.PoseKey(self.ee_id(), k + 1),
+                    gtd.TwistKey(self.ee_id(), k), 0,
                     self.costmodel_posecollo))
             dfg.push_back(
                 gtd.EulerTwistCollocationFactor(
-                    gtd.TwistKey(self.ee_id(), k).key(),
-                    gtd.TwistKey(self.ee_id(), k + 1).key(),
-                    gtd.TwistAccelKey(self.ee_id(), k).key(), 0,
+                    gtd.TwistKey(self.ee_id(), k),
+                    gtd.TwistKey(self.ee_id(), k + 1),
+                    gtd.TwistAccelKey(self.ee_id(), k), 0,
                     self.costmodel_twistcollo))
         dfg.push_back(gtd.PriorFactorDouble(0, dt, self.costmodel_dt))
         return dfg
@@ -226,13 +226,11 @@ class Cdpr:
         for k, l, ldot in zip(ks, ls, ldots):
             for ji, (lval, ldotval) in enumerate(zip(l, ldot)):
                 graph.push_back(
-                    gtd.PriorFactorDouble(
-                        gtd.JointAngleKey(ji, k).key(), lval,
-                        self.costmodel_prior_l))
+                    gtd.PriorFactorDouble(gtd.JointAngleKey(ji, k), lval,
+                                          self.costmodel_prior_l))
                 graph.push_back(
-                    gtd.PriorFactorDouble(
-                        gtd.JointVelKey(ji, k).key(), ldotval,
-                        self.costmodel_prior_ldot))
+                    gtd.PriorFactorDouble(gtd.JointVelKey(ji, k), ldotval,
+                                          self.costmodel_prior_ldot))
         return graph
 
     def priors_ik(self, ks=[], Ts=[], Vs=[]):
@@ -251,13 +249,11 @@ class Cdpr:
         graph = gtsam.NonlinearFactorGraph()
         for k, T, V in zip(ks, Ts, Vs):
             graph.push_back(
-                gtsam.PriorFactorPose3(
-                    gtd.PoseKey(self.ee_id(), k).key(), T,
-                    self.costmodel_prior_pose))
+                gtsam.PriorFactorPose3(gtd.PoseKey(self.ee_id(), k), T,
+                                       self.costmodel_prior_pose))
             graph.push_back(
-                gtd.PriorFactorVector6(
-                    gtd.TwistKey(self.ee_id(), k).key(), V,
-                    self.costmodel_prior_twist))
+                gtd.PriorFactorVector6(gtd.TwistKey(self.ee_id(), k), V,
+                                       self.costmodel_prior_twist))
         return graph
 
     # note: I am not using the strict definitions for forward/inverse dynamics.
@@ -281,9 +277,8 @@ class Cdpr:
         for k, torques in zip(ks, torquess):
             for ji, torque in enumerate(torques):
                 graph.push_back(
-                    gtd.PriorFactorDouble(
-                        gtd.TorqueKey(ji, k).key(), torque,
-                        self.costmodel_prior_tau))
+                    gtd.PriorFactorDouble(gtd.TorqueKey(ji, k), torque,
+                                          self.costmodel_prior_tau))
         return graph
 
     def priors_fd(self, ks=[], VAs=[]):
@@ -302,7 +297,6 @@ class Cdpr:
         graph = gtsam.NonlinearFactorGraph()
         for k, VA in zip(ks, VAs):
             graph.push_back(
-                gtd.PriorFactorVector6(
-                    gtd.TwistAccelKey(self.ee_id(), k).key(), VA,
-                    self.costmodel_prior_twistaccel))
+                gtd.PriorFactorVector6(gtd.TwistAccelKey(self.ee_id(), k), VA,
+                                       self.costmodel_prior_twistaccel))
         return graph

--- a/gtdynamics/cablerobot/src/cdpr_planar_controller.py
+++ b/gtdynamics/cablerobot/src/cdpr_planar_controller.py
@@ -104,13 +104,13 @@ class CdprController(CdprControllerBase):
             for ji in range(4):
                 fg.push_back(
                     gtd.PriorFactorDouble(
-                        gtd.TorqueKey(ji, k).key(), 0.0,
+                        gtd.TorqueKey(ji, k), 0.0,
                         gtsam.noiseModel.Diagonal.Precisions(R)))
         # state objective costs
         cost_x = gtsam.noiseModel.Isotropic.Sigma(6, 0.001) if Q is None else \
             gtsam.noiseModel.Diagonal.Precisions(Q)
         for k in range(N):
             fg.push_back(
-                gtsam.PriorFactorPose3(
-                    gtd.PoseKey(cdpr.ee_id(), k).key(), pdes[k], cost_x))
+                gtsam.PriorFactorPose3(gtd.PoseKey(cdpr.ee_id(), k), pdes[k],
+                                       cost_x))
         return fg

--- a/gtdynamics/cablerobot/src/test_cdpr_planar.py
+++ b/gtdynamics/cablerobot/src/test_cdpr_planar.py
@@ -108,17 +108,15 @@ class TestCdprPlanar(GtsamTestCase):
             cdpr.priors_fd([0], [gtd.TwistAccel(values, cdpr.ee_id(), 0)]))
         # redundancy resolution
         dfg.push_back(
-            gtd.PriorFactorDouble(
-                gtd.TorqueKey(1, 0).key(), 0.0,
-                gtsam.noiseModel.Unit.Create(1)))
+            gtd.PriorFactorDouble(gtd.TorqueKey(1, 0), 0.0,
+                                  gtsam.noiseModel.Unit.Create(1)))
         dfg.push_back(
-            gtd.PriorFactorDouble(
-                gtd.TorqueKey(2, 0).key(), 0.0,
-                gtsam.noiseModel.Unit.Create(1)))
+            gtd.PriorFactorDouble(gtd.TorqueKey(2, 0), 0.0,
+                                  gtsam.noiseModel.Unit.Create(1)))
         # initialize and solve
         init = gtsam.Values(values)
         for ji in range(4):
-            init.erase(gtd.TorqueKey(ji, 0).key())
+            init.erase(gtd.TorqueKey(ji, 0))
             gtd.InsertTorque(init, ji, 0, -1)
         results = gtsam.LevenbergMarquardtOptimizer(dfg, init).optimize()
         self.gtsamAssertEquals(results, values)

--- a/gtdynamics/dynamics/DynamicsGraph.cpp
+++ b/gtdynamics/dynamics/DynamicsGraph.cpp
@@ -299,7 +299,7 @@ gtsam::NonlinearFactorGraph DynamicsGraph::dynamicsFactors(
     int i = link->id();
     if (!link->isFixed()) {
       const auto &connected_joints = link->joints();
-      std::vector<DynamicsSymbol> wrench_keys;
+      std::vector<gtsam::Key> wrench_keys;
 
       // Add wrench keys for joints.
       for (auto &&joint : connected_joints)

--- a/gtdynamics/dynamics/DynamicsGraph.h
+++ b/gtdynamics/dynamics/DynamicsGraph.h
@@ -30,21 +30,6 @@ namespace gtdynamics {
 
 using JointValueMap = std::map<std::string, double>;
 
-/// Shorthand for C_i_c_k, for contact wrench c on i-th link at time step k.
-inline DynamicsSymbol ContactWrenchKey(int i, int c, int k = 0) {
-  return DynamicsSymbol::LinkJointSymbol("C", i, c, k);
-}
-
-/* Shorthand for dt_k, for duration for timestep dt_k during phase k. */
-inline DynamicsSymbol PhaseKey(int k) {
-  return DynamicsSymbol::SimpleSymbol("dt", k);
-}
-
-/* Shorthand for t_k, time at time step k. */
-inline DynamicsSymbol TimeKey(int k) {
-  return DynamicsSymbol::SimpleSymbol("t", k);
-}
-
 /** Collocation methods. */
 enum CollocationScheme { Euler, RungeKutta, Trapezoidal, HermiteSimpson };
 

--- a/gtdynamics/factors/WrenchFactor.h
+++ b/gtdynamics/factors/WrenchFactor.h
@@ -15,7 +15,6 @@
 
 #include <gtdynamics/universal_robot/Joint.h>
 #include <gtdynamics/universal_robot/Link.h>
-#include <gtdynamics/utils/DynamicsSymbol.h>
 #include <gtdynamics/utils/utils.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/Vector.h>
@@ -44,7 +43,7 @@ namespace gtdynamics {
  */
 inline gtsam::NoiseModelFactor::shared_ptr WrenchFactor(
     const gtsam::SharedNoiseModel &cost_model, const LinkConstSharedPtr &link,
-    const std::vector<DynamicsSymbol> &wrench_keys, int time,
+    const std::vector<gtsam::Key> &wrench_keys, int time,
     const boost::optional<gtsam::Vector3> &gravity = boost::none) {
   return boost::make_shared<gtsam::ExpressionFactor<gtsam::Vector6>>(
       cost_model, gtsam::Vector6::Zero(),

--- a/gtdynamics/jumpingrobot/src/actuation_graph_builder.py
+++ b/gtdynamics/jumpingrobot/src/actuation_graph_builder.py
@@ -74,9 +74,9 @@ class ActuationGraphBuilder:
         V_a_key = Actuator.VolumeKey(j, k)
         delta_x_key = Actuator.ContractionKey(j, k)
         f_a_key = Actuator.ForceKey(j, k)
-        torque_key = gtd.TorqueKey(j, k).key()
-        q_key = gtd.JointAngleKey(j, k).key()
-        v_key = gtd.JointVelKey(j, k).key()
+        torque_key = gtd.TorqueKey(j, k)
+        q_key = gtd.JointAngleKey(j, k)
+        v_key = gtd.JointVelKey(j, k)
 
         graph = NonlinearFactorGraph()
         graph.add(
@@ -116,7 +116,7 @@ class ActuationGraphBuilder:
         mdot_sigma_key = Actuator.MassRateActualKey(j, k)
         To_a_key = Actuator.ValveOpenTimeKey(j)
         Tc_a_key = Actuator.ValveCloseTimeKey(j)
-        t_key = gtd.TimeKey(k).key()
+        t_key = gtd.TimeKey(k)
 
         graph = gtsam.NonlinearFactorGraph()
         graph.add(
@@ -144,7 +144,7 @@ class ActuationGraphBuilder:
             phase = step_phases[time_step]
             k_prev = time_step
             k_curr = time_step + 1
-            dt_key = gtd.PhaseKey(phase).key()
+            dt_key = gtd.PhaseKey(phase)
 
             # collcoation on actuator mass
             mdot_prev_keys = []

--- a/gtdynamics/jumpingrobot/src/jr_graph_builder.py
+++ b/gtdynamics/jumpingrobot/src/jr_graph_builder.py
@@ -9,16 +9,14 @@
  * @author Yetong Zhang
 """
 
-
-
 import inspect
 import os.path as osp
 import sys
 
 currentdir = osp.dirname(osp.abspath(inspect.getfile(inspect.currentframe())))
 parentdir = osp.dirname(currentdir)
-sys.path.insert(0,parentdir) 
-sys.path.insert(0,currentdir) 
+sys.path.insert(0, parentdir)
+sys.path.insert(0, currentdir)
 
 import gtdynamics as gtd
 import gtsam
@@ -32,7 +30,6 @@ from robot_graph_builder import RobotGraphBuilder
 
 class JRGraphBuilder:
     """ Class that constructs factor graphs for a jumping robot. """
-
     def __init__(self):
         """Initialize the graph builder, specify all noise models."""
         self.robot_graph_builder = RobotGraphBuilder()
@@ -41,17 +38,19 @@ class JRGraphBuilder:
     def collocation_graph(self, jr: JumpingRobot, step_phases: list):
         """ Create a factor graph containing collocation constraints. """
         graph = self.actuation_graph_builder.collocation_graph(jr, step_phases)
-        graph.push_back(self.robot_graph_builder.collocation_graph(jr, step_phases))
+        graph.push_back(
+            self.robot_graph_builder.collocation_graph(jr, step_phases))
 
         # add collocation factors for time
         for time_step in range(len(step_phases)):
             phase = step_phases[time_step]
             k_prev = time_step
-            k_curr = time_step+1
-            dt_key = gtd.PhaseKey(phase).key()
-            time_prev_key = gtd.TimeKey(k_prev).key()
-            time_curr_key = gtd.TimeKey(k_curr).key()
-            time_col_cost_model = self.robot_graph_builder.graph_builder.opt().time_cost_model
+            k_curr = time_step + 1
+            dt_key = gtd.PhaseKey(phase)
+            time_prev_key = gtd.TimeKey(k_prev)
+            time_curr_key = gtd.TimeKey(k_curr)
+            time_col_cost_model = self.robot_graph_builder.graph_builder.opt(
+            ).time_cost_model
             gtd.AddTimeCollocationFactor(graph, time_prev_key, time_curr_key,
                                          dt_key, time_col_cost_model)
 

--- a/gtdynamics/jumpingrobot/src/jr_simulator.py
+++ b/gtdynamics/jumpingrobot/src/jr_simulator.py
@@ -55,9 +55,9 @@ class JRSimulator:
             JRValues.integrate_mass(self.jr, values, k, dt)
 
         # integrate time
-        t_prev = values.atDouble(gtd.TimeKey(k - 1).key())
+        t_prev = values.atDouble(gtd.TimeKey(k - 1))
         t_curr = t_prev + dt
-        values.insert(gtd.TimeKey(k).key(), t_curr)
+        values.insert(gtd.TimeKey(k), t_curr)
 
     def step_actuation_dynamics(self, k, values):
         """ Perform actuation dynamics by solving the actuation dynamics factor
@@ -86,8 +86,8 @@ class JRSimulator:
             graph = self.jr_graph_builder.actuation_graph_builder.actuator_dynamics_graph(
                 self.jr, actuator, k)
             m_a_key = Actuator.MassKey(j, k)
-            q_key = gtd.JointAngleKey(j, k).key()
-            v_key = gtd.JointVelKey(j, k).key()
+            q_key = gtd.JointAngleKey(j, k)
+            v_key = gtd.JointVelKey(j, k)
             m_a = values.atDouble(m_a_key)
             q = values.atDouble(q_key)
             v = values.atDouble(v_key)
@@ -145,14 +145,14 @@ class JRSimulator:
         # solve q level
         graph_q = robot_graph_builder.graph_builder.qFactors(
             self.jr.robot, k, None)
-        pose_key = gtd.PoseKey(torso_i, k).key()
+        pose_key = gtd.PoseKey(torso_i, k)
         torso_pose = gtd.Pose(values, torso_i, k)
         graph_q.add(
             gtsam.PriorFactorPose3(pose_key, torso_pose, opt.p_cost_model))
         if "ground" not in link_names:
             for joint in self.jr.robot.joints():
                 j = joint.id()
-                q_key = gtd.JointAngleKey(j, k).key()
+                q_key = gtd.JointAngleKey(j, k)
                 graph_q.add(
                     gtd.PriorFactorDouble(q_key, gtd.JointAngle(values, j, k),
                                           opt.prior_q_cost_model))
@@ -164,20 +164,20 @@ class JRSimulator:
         # solve v level
         graph_v = robot_graph_builder.graph_builder.vFactors(
             self.jr.robot, k, None)
-        twist_key = gtd.TwistKey(torso_i, k).key()
+        twist_key = gtd.TwistKey(torso_i, k)
         torso_twist = gtd.Twist(values, torso_i, k)
         graph_v.add(
             gtd.PriorFactorVector6(twist_key, torso_twist, opt.v_cost_model))
         for joint in self.jr.robot.joints():
             j = joint.id()
-            q_key = gtd.JointAngleKey(j, k).key()
+            q_key = gtd.JointAngleKey(j, k)
             graph_v.add(
                 gtd.PriorFactorDouble(q_key, init_values.atDouble(q_key),
                                       opt.prior_q_cost_model))
         if not "ground" in link_names:
             for joint in self.jr.robot.joints():
                 j = joint.id()
-                v_key = gtd.JointVelKey(j, k).key()
+                v_key = gtd.JointVelKey(j, k)
                 graph_v.add(
                     gtd.PriorFactorDouble(v_key, gtd.JointVel(values, j, k),
                                           opt.prior_qv_cost_model))
@@ -196,9 +196,9 @@ class JRSimulator:
 
         for joint in self.jr.robot.joints():
             j = joint.id()
-            q_key = gtd.JointAngleKey(j, k).key()
-            v_key = gtd.JointVelKey(j, k).key()
-            torque_key = gtd.TorqueKey(j, k).key()
+            q_key = gtd.JointAngleKey(j, k)
+            v_key = gtd.JointVelKey(j, k)
+            torque_key = gtd.TorqueKey(j, k)
             graph_dynamics.add(
                 gtd.PriorFactorDouble(q_key, init_values.atDouble(q_key),
                                       opt.prior_q_cost_model))
@@ -211,8 +211,8 @@ class JRSimulator:
                                       opt.prior_t_cost_model))
         for link in self.jr.robot.links():
             i = link.id()
-            pose_key = gtd.PoseKey(i, k).key()
-            twist_key = gtd.TwistKey(i, k).key()
+            pose_key = gtd.PoseKey(i, k)
+            twist_key = gtd.TwistKey(i, k)
             graph_dynamics_keys = [
                 key for key in gtd.KeySetToKeyVector(graph_dynamics.keys())
             ]
@@ -257,7 +257,7 @@ class JRSimulator:
         graph = robot_graph_builder.dynamics_graph(self.jr, k)
         for acutator in self.jr.actuators:
             j = acutator.j
-            torque_key = gtd.TorqueKey(j, k).key()
+            torque_key = gtd.TorqueKey(j, k)
             torque = values.atDouble(torque_key)
             graph.add(
                 gtd.PriorFactorDouble(torque_key, torque,
@@ -265,11 +265,11 @@ class JRSimulator:
 
         # prior on torso link pose and twist
         i = self.jr.robot.link("torso").id()
-        pose_key = gtd.PoseKey(i, k).key()
+        pose_key = gtd.PoseKey(i, k)
         torso_pose = gtd.Pose(values, i, k)
         graph.add(
             gtsam.PriorFactorPose3(pose_key, torso_pose, opt.p_cost_model))
-        twist_key = gtd.TwistKey(i, k).key()
+        twist_key = gtd.TwistKey(i, k)
         torso_twist = gtd.Twist(values, i, k)
         graph.add(
             gtd.PriorFactorVector6(twist_key, torso_twist, opt.v_cost_model))
@@ -278,11 +278,11 @@ class JRSimulator:
         if "ground" not in link_names:
             for joint in self.jr.robot.joints():
                 j = joint.id()
-                q_key = gtd.JointAngleKey(j, k).key()
+                q_key = gtd.JointAngleKey(j, k)
                 graph.add(
                     gtd.PriorFactorDouble(q_key, gtd.JointAngle(values, j, k),
                                           opt.prior_q_cost_model))
-                v_key = gtd.JointVelKey(j, k).key()
+                v_key = gtd.JointVelKey(j, k)
                 graph.add(
                     gtd.PriorFactorDouble(v_key, gtd.JointVel(values, j, k),
                                           opt.prior_v_cost_model))

--- a/gtdynamics/jumpingrobot/src/jr_values.py
+++ b/gtdynamics/jumpingrobot/src/jr_values.py
@@ -60,8 +60,8 @@ class JRValues:
         for joint in jr.robot.joints():
             j = joint.id()
             name = joint.name()
-            q_key = gtd.JointAngleKey(j, 0).key()
-            v_key = gtd.JointVelKey(j, 0).key()
+            q_key = gtd.JointAngleKey(j, 0)
+            v_key = gtd.JointVelKey(j, 0)
             q = float(jr.init_config["qs"][name])
             v = float(jr.init_config["vs"][name])
             values.insert(q_key, q)
@@ -82,14 +82,14 @@ class JRValues:
             values.insert(Tc_key, float(controls["Tcs"][name]))
 
         # time for the first step
-        values.insert(gtd.TimeKey(0).key(), 0)
+        values.insert(gtd.TimeKey(0), 0)
         return values
 
     @staticmethod
     def get_known_values_actuator(j, k, values):
         """ Construct known values for actuator dynamics graph. """
-        q_key = gtd.JointAngleKey(j, k).key()
-        v_key = gtd.JointVelKey(j, k).key()
+        q_key = gtd.JointAngleKey(j, k)
+        v_key = gtd.JointVelKey(j, k)
         m_a_key = Actuator.MassKey(j, k)
 
         init_values = gtsam.Values()
@@ -110,7 +110,7 @@ class JRValues:
         V_a_key = Actuator.VolumeKey(j, k)
         delta_x_key = Actuator.ContractionKey(j, k)
         f_a_key = Actuator.ForceKey(j, k)
-        torque_key = gtd.TorqueKey(j, k).key()
+        torque_key = gtd.TorqueKey(j, k)
 
         init_values.insert(P_s_key,
                            values.atDouble(Actuator.SourcePressureKey(k - 1)))
@@ -120,8 +120,8 @@ class JRValues:
                            values.atDouble(Actuator.ContractionKey(j, k - 1)))
         init_values.insert(f_a_key,
                            values.atDouble(Actuator.ForceKey(j, k - 1)))
-        init_values.insert(torque_key,
-                           values.atDouble(gtd.TorqueKey(j, k - 1).key()))
+        init_values.insert(torque_key, values.atDouble(gtd.TorqueKey(j,
+                                                                     k - 1)))
         init_values.insert(V_a_key,
                            values.atDouble(Actuator.VolumeKey(j, k - 1)))
         return init_values
@@ -185,11 +185,11 @@ class JRValues:
 
         To_a_key = Actuator.ValveOpenTimeKey(j)
         Tc_a_key = Actuator.ValveCloseTimeKey(j)
-        t_key = gtd.TimeKey(k).key()
+        t_key = gtd.TimeKey(k)
         mdot_sigma_key = Actuator.MassRateActualKey(j, k)
         To = values.atDouble(To_a_key)
         Tc = values.atDouble(Tc_a_key)
-        curr_time = values.atDouble(gtd.TimeKey(k).key())
+        curr_time = values.atDouble(gtd.TimeKey(k))
         valve_control_factor = gtd.ValveControlFactor(t_key, To_a_key,
                                                       Tc_a_key, mdot_key,
                                                       mdot_sigma_key,
@@ -210,7 +210,7 @@ class JRValues:
         V_a_key = Actuator.VolumeKey(j, k)
         delta_x_key = Actuator.ContractionKey(j, k)
         f_a_key = Actuator.ForceKey(j, k)
-        torque_key = gtd.TorqueKey(j, k).key()
+        torque_key = gtd.TorqueKey(j, k)
 
         init_values.insert(P_s_key, values.atDouble(P_s_key))
         init_values.insert(P_a_key, 101.325)
@@ -231,8 +231,8 @@ class JRValues:
         init_values = gtsam.Values()
         for joint in robot.joints():
             j = joint.id()
-            q_key = gtd.JointAngleKey(j, k).key()
-            v_key = gtd.JointVelKey(j, k).key()
+            q_key = gtd.JointAngleKey(j, k)
+            v_key = gtd.JointVelKey(j, k)
             JRValues.copy_value(values, init_values, q_key)
             JRValues.copy_value(values, init_values, v_key)
             gtd.InsertJointAccel(init_values, j, k,
@@ -243,16 +243,16 @@ class JRValues:
                              gtd.Wrench(values, i1, j, k - 1))
             gtd.InsertWrench(init_values, i2, j, k,
                              gtd.Wrench(values, i2, j, k - 1))
-            torque_key = gtd.TorqueKey(j, k).key()
+            torque_key = gtd.TorqueKey(j, k)
             JRValues.copy_value(values, init_values, torque_key)
 
         for link in robot.links():
             i = link.id()
-            if values.exists(gtd.PoseKey(i, k).key()):
+            if values.exists(gtd.PoseKey(i, k)):
                 gtd.InsertPose(init_values, i, k, gtd.Pose(values, i, k))
             else:
                 gtd.InsertPose(init_values, i, k, gtd.Pose(values, i, k - 1))
-            if values.exists(gtd.TwistKey(i, k).key()):
+            if values.exists(gtd.TwistKey(i, k)):
                 gtd.InsertTwist(init_values, i, k, gtd.Twist(values, i, k))
             else:
                 gtd.InsertTwist(init_values, i, k, gtd.Twist(values, i, k - 1))
@@ -278,8 +278,8 @@ class JRValues:
         init_values = gtsam.Values()
         for link in jr.robot.links():
             i = link.id()
-            pose_key = gtd.PoseKey(i, k).key()
-            twist_key = gtd.TwistKey(i, k).key()
+            pose_key = gtd.PoseKey(i, k)
+            twist_key = gtd.TwistKey(i, k)
             pose = fk_results.atPose3(pose_key)
             if values.exists(pose_key):
                 pose = gtd.Pose(values, i, k)
@@ -293,8 +293,8 @@ class JRValues:
         # assign zeros to unknown values
         for joint in jr.robot.joints():
             j = joint.id()
-            q_key = gtd.JointAngleKey(j, k).key()
-            v_key = gtd.JointVelKey(j, k).key()
+            q_key = gtd.JointAngleKey(j, k)
+            v_key = gtd.JointVelKey(j, k)
             q = 0.0
             v = 0.0
             if values.exists(q_key):
@@ -308,7 +308,7 @@ class JRValues:
             i2 = joint.child().id()
             gtd.InsertWrench(init_values, i1, j, k, np.zeros(6))
             gtd.InsertWrench(init_values, i2, j, k, np.zeros(6))
-            torque_key = gtd.TorqueKey(j, k).key()
+            torque_key = gtd.TorqueKey(j, k)
             if values.exists(torque_key):
                 gtd.InsertTorque(init_values, j, k,
                                  values.atDouble(torque_key))

--- a/gtdynamics/jumpingrobot/src/jr_visualizer.py
+++ b/gtdynamics/jumpingrobot/src/jr_visualizer.py
@@ -43,10 +43,10 @@ def update_jr_frame(ax, values, jr, k):
         z = pose.z()
         theta = pose.rotation().roll()
         l = 0.55
-        start_y = y - l/2 * np.cos(theta)
-        start_z = z - l/2 * np.sin(theta)
-        end_y = y + l/2 * np.cos(theta)
-        end_z = z + l/2 * np.sin(theta)
+        start_y = y - l / 2 * np.cos(theta)
+        start_z = z - l / 2 * np.sin(theta)
+        end_y = y + l / 2 * np.cos(theta)
+        end_z = z + l / 2 * np.sin(theta)
 
         ax.plot([start_y, end_y], [start_z, end_z], color=color)
 
@@ -92,6 +92,7 @@ def visualize_jr_trajectory(values, jr, num_steps, step=1):
 
     def animate(i):
         update_jr_frame(ax, values, jr, i)
+
     frames = np.arange(0, num_steps, step)
     FuncAnimation(fig, animate, frames=frames, interval=10)
     plt.show()
@@ -100,11 +101,13 @@ def visualize_jr_trajectory(values, jr, num_steps, step=1):
 def make_plot(values, jr, num_steps):
     """ Draw plots of all quantities with time. """
     joint_names = ["knee_r", "hip_r", "hip_l", "knee_l"]
-    colors = {"knee_r": "red",
-              "hip_r": "orange",
-              "hip_l": "green",
-              "knee_l": "blue",
-              "source": "black"}
+    colors = {
+        "knee_r": "red",
+        "hip_r": "orange",
+        "hip_l": "green",
+        "knee_l": "blue",
+        "source": "black"
+    }
 
     qs_dict = {name: [] for name in joint_names}
     vs_dict = {name: [] for name in joint_names}
@@ -124,39 +127,62 @@ def make_plot(values, jr, num_steps):
             qs_dict[name].append(gtd.JointAngle(values, j, k))
             vs_dict[name].append(gtd.JointVel(values, j, k))
             torques_dict[name].append(gtd.Torque(values, j, k))
-            pressures_dict[name].append(values.atDouble(Actuator.PressureKey(j, k)))
+            pressures_dict[name].append(
+                values.atDouble(Actuator.PressureKey(j, k)))
             masses_dict[name].append(values.atDouble(Actuator.MassKey(j, k)))
-            mdots_dict[name].append(values.atDouble(Actuator.MassRateActualKey(j, k)))
-            contractions_dict[name].append(values.atDouble(Actuator.ContractionKey(j, k)))
+            mdots_dict[name].append(
+                values.atDouble(Actuator.MassRateActualKey(j, k)))
+            contractions_dict[name].append(
+                values.atDouble(Actuator.ContractionKey(j, k)))
             forces_dict[name].append(values.atDouble(Actuator.ForceKey(j, k)))
-        masses_dict["source"].append(values.atDouble(Actuator.SourceMassKey(k)))
-        pressures_dict["source"].append(values.atDouble(Actuator.SourcePressureKey(k)))
-        time_list.append(values.atDouble(gtd.TimeKey(k).key()))
+        masses_dict["source"].append(values.atDouble(
+            Actuator.SourceMassKey(k)))
+        pressures_dict["source"].append(
+            values.atDouble(Actuator.SourcePressureKey(k)))
+        time_list.append(values.atDouble(gtd.TimeKey(k)))
 
     fig, axs = plt.subplots(2, 3, sharex=True, figsize=(10, 6.7), dpi=80)
 
     for name in qs_dict.keys():
-        axs[0, 0].plot(time_list, qs_dict[name], label=name, color=colors[name])
+        axs[0, 0].plot(time_list,
+                       qs_dict[name],
+                       label=name,
+                       color=colors[name])
     axs[0, 0].set_title("joint angle")
 
     for name in torques_dict.keys():
-        axs[0, 1].plot(time_list, torques_dict[name], label=name, color=colors[name])
+        axs[0, 1].plot(time_list,
+                       torques_dict[name],
+                       label=name,
+                       color=colors[name])
     axs[0, 1].set_title("torque")
 
     for name in forces_dict.keys():
-        axs[0, 2].plot(time_list, forces_dict[name], label=name, color=colors[name])
+        axs[0, 2].plot(time_list,
+                       forces_dict[name],
+                       label=name,
+                       color=colors[name])
     axs[0, 2].set_title("force")
 
     for name in pressures_dict.keys():
-        axs[1, 0].plot(time_list, pressures_dict[name], label=name, color=colors[name])
+        axs[1, 0].plot(time_list,
+                       pressures_dict[name],
+                       label=name,
+                       color=colors[name])
     axs[1, 0].set_title("pressure")
 
     for name in masses_dict.keys():
-        axs[1, 1].plot(time_list, masses_dict[name], label=name, color=colors[name])
+        axs[1, 1].plot(time_list,
+                       masses_dict[name],
+                       label=name,
+                       color=colors[name])
     axs[1, 1].set_title("mass")
 
     for name in contractions_dict.keys():
-        axs[1, 2].plot(time_list, contractions_dict[name], label=name, color=colors[name])
+        axs[1, 2].plot(time_list,
+                       contractions_dict[name],
+                       label=name,
+                       color=colors[name])
     axs[1, 2].set_title("contraction")
     plt.show()
 

--- a/gtdynamics/jumpingrobot/src/robot_graph_builder.py
+++ b/gtdynamics/jumpingrobot/src/robot_graph_builder.py
@@ -73,7 +73,7 @@ class RobotGraphBuilder:
         for name in ["foot_l", "foot_r"]:
             if name in joint_names:
                 j = jr.robot.joint(name).id()
-                torque_key = gtd.TorqueKey(j, k).key()
+                torque_key = gtd.TorqueKey(j, k)
                 graph.add(
                     gtd.PriorFactorDouble(
                         torque_key, 0.0,
@@ -94,7 +94,7 @@ class RobotGraphBuilder:
             phase = step_phases[time_step]
             k_prev = time_step
             k_curr = time_step + 1
-            dt_key = gtd.PhaseKey(phase).key()
+            dt_key = gtd.PhaseKey(phase)
 
             # collocation on joint angles
             if phase == 3:
@@ -113,12 +113,12 @@ class RobotGraphBuilder:
             # collocation on torso link
             link = jr.robot.link("torso")
             i = link.id()
-            pose_prev_key = gtd.PoseKey(i, k_prev).key()
-            pose_curr_key = gtd.PoseKey(i, k_curr).key()
-            twist_prev_key = gtd.TwistKey(i, k_prev).key()
-            twist_curr_key = gtd.TwistKey(i, k_curr).key()
-            twistaccel_prev_key = gtd.TwistAccelKey(i, k_prev).key()
-            twistaccel_curr_key = gtd.TwistAccelKey(i, k_curr).key()
+            pose_prev_key = gtd.PoseKey(i, k_prev)
+            pose_curr_key = gtd.PoseKey(i, k_curr)
+            twist_prev_key = gtd.TwistKey(i, k_prev)
+            twist_curr_key = gtd.TwistKey(i, k_curr)
+            twistaccel_prev_key = gtd.TwistAccelKey(i, k_prev)
+            twistaccel_curr_key = gtd.TwistAccelKey(i, k_curr)
 
             pose_col_cost_model = self.graph_builder.opt().pose_col_cost_model
             graph.add(

--- a/gtdynamics/jumpingrobot/src/test_jr_values.py
+++ b/gtdynamics/jumpingrobot/src/test_jr_values.py
@@ -29,7 +29,6 @@ from src.jumping_robot import Actuator, JumpingRobot
 
 class TestJRValues(unittest.TestCase):
     """ Tests for jumping robot. """
-
     def setUp(self):
         """ Set up the jumping robot. """
         self.yaml_file_path = osp.join(parentdir, "yaml", "robot_config.yaml")
@@ -46,9 +45,9 @@ class TestJRValues(unittest.TestCase):
         values.insert(Actuator.ValveCloseTimeKey(j), 1)
         P_a_key = Actuator.PressureKey(j, k)
         P_s_key = Actuator.SourcePressureKey(k)
-        t_key = gtd.TimeKey(k).key()
+        t_key = gtd.TimeKey(k)
         values.insert(P_a_key, 101.325)
-        values.insert(P_s_key, 65 * 6894.76/1000)
+        values.insert(P_s_key, 65 * 6894.76 / 1000)
         values.insert(t_key, 0.0001)
 
         mdot, mdot_sigma = JRValues.compute_mass_flow(self.jr, values, j, k)

--- a/gtdynamics/statics/StaticWrenchFactor.cpp
+++ b/gtdynamics/statics/StaticWrenchFactor.cpp
@@ -31,7 +31,7 @@ using gtsam::Vector6;
 namespace gtdynamics {
 
 StaticWrenchFactor::StaticWrenchFactor(
-    const std::vector<DynamicsSymbol> &wrench_keys, gtsam::Key pose_key,
+    const std::vector<gtsam::Key> &wrench_keys, gtsam::Key pose_key,
     const gtsam::noiseModel::Base::shared_ptr &cost_model, double mass,
     const boost::optional<gtsam::Vector3> &gravity)
     : Base(cost_model, wrench_keys), mass_(mass), gravity_(gravity) {

--- a/gtdynamics/statics/StaticWrenchFactor.h
+++ b/gtdynamics/statics/StaticWrenchFactor.h
@@ -49,7 +49,7 @@ class StaticWrenchFactor : public gtsam::NoiseModelFactor {
    * @param gravity (optional) Gravity vector in world frame.
    */
   StaticWrenchFactor(
-      const std::vector<DynamicsSymbol> &wrench_keys, gtsam::Key pose_key,
+      const std::vector<gtsam::Key> &wrench_keys, gtsam::Key pose_key,
       const gtsam::noiseModel::Base::shared_ptr &cost_model, double mass,
       const boost::optional<gtsam::Vector3> &gravity = boost::none);
 

--- a/gtdynamics/statics/StaticsSlice.cpp
+++ b/gtdynamics/statics/StaticsSlice.cpp
@@ -67,7 +67,7 @@ gtsam::NonlinearFactorGraph Statics::graph(const Slice& slice,
     int i = link->id();
     if (link->isFixed()) continue;
     const auto& connected_joints = link->joints();
-    std::vector<DynamicsSymbol> wrench_keys;
+    std::vector<gtsam::Key> wrench_keys;
 
     // Add wrench keys for joints.
     for (auto&& joint : connected_joints)

--- a/gtdynamics/universal_robot/Link.cpp
+++ b/gtdynamics/universal_robot/Link.cpp
@@ -25,7 +25,7 @@ namespace gtdynamics {
 
 /* ************************************************************************* */
 gtsam::Vector6_ Link::wrenchConstraint(
-    const std::vector<DynamicsSymbol>& wrench_keys, uint64_t t,
+    const std::vector<gtsam::Key>& wrench_keys, uint64_t t,
     const boost::optional<gtsam::Vector3>& gravity) const {
   // Collect wrenches to implement L&P Equation 8.48 (F = ma)
   std::vector<gtsam::Vector6_> wrenches;

--- a/gtdynamics/universal_robot/Link.h
+++ b/gtdynamics/universal_robot/Link.h
@@ -185,7 +185,7 @@ class Link : public boost::enable_shared_from_this<Link> {
    * @param gravity Gravitional constant.
    */
   gtsam::Vector6_ wrenchConstraint(
-      const std::vector<DynamicsSymbol> &wrench_keys, uint64_t t = 0,
+      const std::vector<gtsam::Key> &wrench_keys, uint64_t t = 0,
       const boost::optional<gtsam::Vector3> &gravity = boost::none) const;
 
  private:

--- a/gtdynamics/utils/values.h
+++ b/gtdynamics/utils/values.h
@@ -40,57 +40,57 @@ class KeyDoesNotExist : public gtsam::ValuesKeyDoesNotExist {
  ************************************************************************* */
 /// Shorthand for q_j_t, for j-th joint angle at time t.
 inline gtsam::Key JointAngleKey(int j, int t = 0) {
-  return DynamicsSymbol::JointSymbol("q", j, t).key();
+  return DynamicsSymbol::JointSymbol("q", j, t);
 }
 
 /// Shorthand for v_j_t, for j-th joint velocity at time t.
 inline gtsam::Key JointVelKey(int j, int t = 0) {
-  return DynamicsSymbol::JointSymbol("v", j, t).key();
+  return DynamicsSymbol::JointSymbol("v", j, t);
 }
 
 /// Shorthand for a_j_t, for j-th joint acceleration at time t.
 inline gtsam::Key JointAccelKey(int j, int t = 0) {
-  return DynamicsSymbol::JointSymbol("a", j, t).key();
+  return DynamicsSymbol::JointSymbol("a", j, t);
 }
 
 /// Shorthand for T_j_t, for torque on the j-th joint at time t.
 inline gtsam::Key TorqueKey(int j, int t = 0) {
-  return DynamicsSymbol::JointSymbol("T", j, t).key();
+  return DynamicsSymbol::JointSymbol("T", j, t);
 }
 
 /// Shorthand for p_i_t, for COM pose on the i-th link at time t.
 inline gtsam::Key PoseKey(int i, int t = 0) {
-  return DynamicsSymbol::LinkSymbol("p", i, t).key();
+  return DynamicsSymbol::LinkSymbol("p", i, t);
 }
 
 /// Shorthand for V_i_t, for 6D link twist vector on the i-th link.
 inline gtsam::Key TwistKey(int i, int t = 0) {
-  return DynamicsSymbol::LinkSymbol("V", i, t).key();
+  return DynamicsSymbol::LinkSymbol("V", i, t);
 }
 
 /// Shorthand for A_i_t, for twist accelerations on the i-th link at time t.
 inline gtsam::Key TwistAccelKey(int i, int t = 0) {
-  return DynamicsSymbol::LinkSymbol("A", i, t).key();
+  return DynamicsSymbol::LinkSymbol("A", i, t);
 }
 
 /// Shorthand for F_i_j_t, wrenches at j-th joint on the i-th link at time t.
 inline gtsam::Key WrenchKey(int i, int j, int t = 0) {
-  return DynamicsSymbol::LinkJointSymbol("F", i, j, t).key();
+  return DynamicsSymbol::LinkJointSymbol("F", i, j, t);
 }
 
 /// Shorthand for C_i_c_k, for contact wrench c on i-th link at time step k.
 inline gtsam::Key ContactWrenchKey(int i, int c, int k = 0) {
-  return DynamicsSymbol::LinkJointSymbol("C", i, c, k).key();
+  return DynamicsSymbol::LinkJointSymbol("C", i, c, k);
 }
 
 /* Shorthand for dt_k, for duration for timestep dt_k during phase k. */
 inline gtsam::Key PhaseKey(int k) {
-  return DynamicsSymbol::SimpleSymbol("dt", k).key();
+  return DynamicsSymbol::SimpleSymbol("dt", k);
 }
 
 /* Shorthand for t_k, time at time step k. */
 inline gtsam::Key TimeKey(int k) {
-  return DynamicsSymbol::SimpleSymbol("t", k).key();
+  return DynamicsSymbol::SimpleSymbol("t", k);
 }
 
 /// Custom retrieval that throws KeyDoesNotExist

--- a/gtdynamics/utils/values.h
+++ b/gtdynamics/utils/values.h
@@ -39,43 +39,58 @@ class KeyDoesNotExist : public gtsam::ValuesKeyDoesNotExist {
   Key definitions.
  ************************************************************************* */
 /// Shorthand for q_j_t, for j-th joint angle at time t.
-inline DynamicsSymbol JointAngleKey(int j, int t = 0) {
-  return DynamicsSymbol::JointSymbol("q", j, t);
+inline gtsam::Key JointAngleKey(int j, int t = 0) {
+  return DynamicsSymbol::JointSymbol("q", j, t).key();
 }
 
 /// Shorthand for v_j_t, for j-th joint velocity at time t.
-inline DynamicsSymbol JointVelKey(int j, int t = 0) {
-  return DynamicsSymbol::JointSymbol("v", j, t);
+inline gtsam::Key JointVelKey(int j, int t = 0) {
+  return DynamicsSymbol::JointSymbol("v", j, t).key();
 }
 
 /// Shorthand for a_j_t, for j-th joint acceleration at time t.
-inline DynamicsSymbol JointAccelKey(int j, int t = 0) {
-  return DynamicsSymbol::JointSymbol("a", j, t);
+inline gtsam::Key JointAccelKey(int j, int t = 0) {
+  return DynamicsSymbol::JointSymbol("a", j, t).key();
 }
 
 /// Shorthand for T_j_t, for torque on the j-th joint at time t.
-inline DynamicsSymbol TorqueKey(int j, int t = 0) {
-  return DynamicsSymbol::JointSymbol("T", j, t);
+inline gtsam::Key TorqueKey(int j, int t = 0) {
+  return DynamicsSymbol::JointSymbol("T", j, t).key();
 }
 
 /// Shorthand for p_i_t, for COM pose on the i-th link at time t.
-inline DynamicsSymbol PoseKey(int i, int t = 0) {
-  return DynamicsSymbol::LinkSymbol("p", i, t);
+inline gtsam::Key PoseKey(int i, int t = 0) {
+  return DynamicsSymbol::LinkSymbol("p", i, t).key();
 }
 
 /// Shorthand for V_i_t, for 6D link twist vector on the i-th link.
-inline DynamicsSymbol TwistKey(int i, int t = 0) {
-  return DynamicsSymbol::LinkSymbol("V", i, t);
+inline gtsam::Key TwistKey(int i, int t = 0) {
+  return DynamicsSymbol::LinkSymbol("V", i, t).key();
 }
 
 /// Shorthand for A_i_t, for twist accelerations on the i-th link at time t.
-inline DynamicsSymbol TwistAccelKey(int i, int t = 0) {
-  return DynamicsSymbol::LinkSymbol("A", i, t);
+inline gtsam::Key TwistAccelKey(int i, int t = 0) {
+  return DynamicsSymbol::LinkSymbol("A", i, t).key();
 }
 
 /// Shorthand for F_i_j_t, wrenches at j-th joint on the i-th link at time t.
-inline DynamicsSymbol WrenchKey(int i, int j, int t = 0) {
-  return DynamicsSymbol::LinkJointSymbol("F", i, j, t);
+inline gtsam::Key WrenchKey(int i, int j, int t = 0) {
+  return DynamicsSymbol::LinkJointSymbol("F", i, j, t).key();
+}
+
+/// Shorthand for C_i_c_k, for contact wrench c on i-th link at time step k.
+inline gtsam::Key ContactWrenchKey(int i, int c, int k = 0) {
+  return DynamicsSymbol::LinkJointSymbol("C", i, c, k).key();
+}
+
+/* Shorthand for dt_k, for duration for timestep dt_k during phase k. */
+inline gtsam::Key PhaseKey(int k) {
+  return DynamicsSymbol::SimpleSymbol("dt", k).key();
+}
+
+/* Shorthand for t_k, time at time step k. */
+inline gtsam::Key TimeKey(int k) {
+  return DynamicsSymbol::SimpleSymbol("t", k).key();
 }
 
 /// Custom retrieval that throws KeyDoesNotExist

--- a/python/tests/test_factors.py
+++ b/python/tests/test_factors.py
@@ -24,8 +24,8 @@ class TestFactors(unittest.TestCase):
     """
     def setUp(self):
         self.k = 0
-        self.wTp_key = gtd.PoseKey(0, self.k).key()
-        self.wTc_key = gtd.PoseKey(1, self.k).key()
+        self.wTp_key = gtd.PoseKey(0, self.k)
+        self.wTc_key = gtd.PoseKey(1, self.k)
 
         ROBOT_FILE = osp.join(gtd.SDF_PATH, "test", "simple_rr.sdf")
         self.robot = gtd.CreateRobotFromFile(str(ROBOT_FILE), "simple_rr_sdf")

--- a/python/tests/test_forward_kinematics.py
+++ b/python/tests/test_forward_kinematics.py
@@ -55,7 +55,7 @@ class TestRobot(GtsamTestCase):
         end_link = self.robot.link(end_link_name)
         factor = gtd.ForwardKinematicsFactor(
             X(t),
-            gtd.PoseKey(end_link.id(), t).key(),  # wTleg
+            gtd.PoseKey(end_link.id(), t),  # wTleg
             self.robot,
             self.base_name,
             end_link_name,
@@ -69,7 +69,7 @@ class TestRobot(GtsamTestCase):
         fk = self.robot.forwardKinematics(self.joint_angles, t, self.base_name)
         end_link_pose = gtd.Pose(fk, end_link.id(), t)
 
-        values.insert(gtd.PoseKey(end_link.id(), t).key(), end_link_pose)
+        values.insert(gtd.PoseKey(end_link.id(), t), end_link_pose)
 
         graph = gtsam.NonlinearFactorGraph()
         graph.push_back(factor)

--- a/python/tests/test_four_bar.py
+++ b/python/tests/test_four_bar.py
@@ -99,7 +99,7 @@ class TestFourBar(unittest.TestCase):
         optimizer = gtsam.LevenbergMarquardtOptimizer(graph, init_values)
         result = optimizer.optimize()
 
-        a1_key = gtd.JointAccelKey(1, 0).key()
+        a1_key = gtd.JointAccelKey(1, 0)
         a1 = result.atDouble(a1_key)
         self.assertAlmostEqual(a1, 0.125, 5)  # regression. Show work!
 

--- a/python/tests/test_print.py
+++ b/python/tests/test_print.py
@@ -29,13 +29,13 @@ class TestPrint(unittest.TestCase):
         """Checks that printing NonlinearFactorGraph uses the GTDKeyFormatter"""
         fg = gtd.NonlinearFactorGraph()
         fg.push_back(
-            gtd.MinTorqueFactor(
-                gtd.TorqueKey(0, 0).key(), gtsam.noiseModel.Unit.Create(1)))
+            gtd.MinTorqueFactor(gtd.TorqueKey(0, 0),
+                                gtsam.noiseModel.Unit.Create(1)))
         self.assertTrue('T(0)0' in fg.__repr__())
 
     def test_key_formatter(self):
         """Tests print method with various key formatters"""
-        torqueKey = gtd.TorqueKey(0, 0).key()
+        torqueKey = gtd.TorqueKey(0, 0)
         factor = gtd.MinTorqueFactor(torqueKey,
                                      gtsam.noiseModel.Unit.Create(1))
         with patch('sys.stdout', new=StringIO()) as fake_out:


### PR DESCRIPTION
Something that has been a bit irksome for me has been the need to specify `.key()` for the various key helpers.

Example:
```python
j_key = gtd.JointAngleKey(0, t=10).key()
```

instead of
```python
j_key = gtd.JointAngleKey(0, t=10)
```
which is both cleaner and shorter. If the function says "Key" it should return a Key, right?

This PR updates the code to remedy this. Updating dependent code should be a cinch (global replace `.key()` with the empty string) and should make the library more user friendly.