### PR TITLE
Fix Python CI workflow 

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -50,6 +50,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
+            sudo apt-get -y update
             sudo apt-get install -y g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
             echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
             echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Install Dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo apt-get -y update
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
-            sudo apt-get -y update
             sudo apt-get install -y g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
             echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
             echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV


### PR DESCRIPTION
Python CI doesn't pass, since it can't install dependencies for ubuntu 22.
happened for both ubuntu 22 gcc and clang.