### PR TITLE
DynamicsSymbol needs #include<limits> when boost serialization is OFF

### DIFF
--- a/gtdynamics/utils/DynamicsSymbol.h
+++ b/gtdynamics/utils/DynamicsSymbol.h
@@ -16,6 +16,8 @@
 #include <gtsam/inference/Key.h>
 #include <gtsam/inference/Symbol.h>
 
+#include <limits>
+
 namespace gtdynamics {
 
 class DynamicsSymbol {


### PR DESCRIPTION
This PR fixes an error that is encountered when attempting to compile GTDynamics when `GTSAM_ENABLE_BOOST_SERIALIZATION` is OFF.

The error encountered with gcc-11 is 'numeric_limits' is not a member of 'std'