### PR TITLE
Use NoiseModelFactorN as factor base class

### DIFF
--- a/gtdynamics/cablerobot/factors/CableLengthFactor.h
+++ b/gtdynamics/cablerobot/factors/CableLengthFactor.h
@@ -22,12 +22,12 @@ namespace gtdynamics {
  * end effector pose and cable length
  */
 class CableLengthFactor
-    : public gtsam::NoiseModelFactor2<double, gtsam::Pose3> {
+    : public gtsam::NoiseModelFactorN<double, gtsam::Pose3> {
  private:
   using Pose3 = gtsam::Pose3;
   using Point3 = gtsam::Point3;
   using This = CableLengthFactor;
-  using Base = gtsam::NoiseModelFactor2<double, Pose3>;
+  using Base = gtsam::NoiseModelFactorN<double, Pose3>;
 
   Point3 wPa_, xPb_;
 
@@ -86,7 +86,7 @@ class CableLengthFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/cablerobot/factors/CableTensionFactor.h
+++ b/gtdynamics/cablerobot/factors/CableTensionFactor.h
@@ -23,14 +23,14 @@ namespace gtdynamics {
  * amongst cable tension, end effector pose, and wrench felt by the end effector
  */
 class CableTensionFactor
-    : public gtsam::NoiseModelFactor3<double, gtsam::Pose3, gtsam::Vector6> {
+    : public gtsam::NoiseModelFactorN<double, gtsam::Pose3, gtsam::Vector6> {
  private:
   using Pose3 = gtsam::Pose3;
   using Point3 = gtsam::Point3;
   using Vector6 = gtsam::Vector6;
   using Vector3 = gtsam::Vector3;
   using This = CableTensionFactor;
-  using Base = gtsam::NoiseModelFactor3<double, Pose3, Vector6>;
+  using Base = gtsam::NoiseModelFactorN<double, Pose3, Vector6>;
 
   Point3 wPa_, xPb_;
 
@@ -113,7 +113,7 @@ class CableTensionFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor3", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/cablerobot/factors/CableVelocityFactor.h
+++ b/gtdynamics/cablerobot/factors/CableVelocityFactor.h
@@ -23,14 +23,14 @@ namespace gtdynamics {
  * amongst cable velocity, end-effector pose, and end-effector twist
  */
 class CableVelocityFactor
-    : public gtsam::NoiseModelFactor3<double, gtsam::Pose3, gtsam::Vector6> {
+    : public gtsam::NoiseModelFactorN<double, gtsam::Pose3, gtsam::Vector6> {
  private:
   using Point3 = gtsam::Point3;
   using Vector3 = gtsam::Vector3;
   using Pose3 = gtsam::Pose3;
   using Vector6 = gtsam::Vector6;
   using This = CableVelocityFactor;
-  using Base = gtsam::NoiseModelFactor3<double, Pose3, Vector6>;
+  using Base = gtsam::NoiseModelFactorN<double, Pose3, Vector6>;
 
   Point3 wPa_, xPb_;
 
@@ -101,7 +101,7 @@ class CableVelocityFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor3", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/factors/CollocationFactors.h
+++ b/gtdynamics/factors/CollocationFactors.h
@@ -51,11 +51,11 @@ gtsam::Pose3 predictPose(const gtsam::Pose3 &pose_t0,
  * of current and next time steps
  */
 class EulerPoseCollocationFactor
-    : public gtsam::NoiseModelFactor4<gtsam::Pose3, gtsam::Pose3,
+    : public gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3,
                                       gtsam::Vector6, double> {
  private:
   using This = EulerPoseCollocationFactor;
-  using Base = gtsam::NoiseModelFactor4<gtsam::Pose3, gtsam::Pose3,
+  using Base = gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3,
                                         gtsam::Vector6, double>;
 
  public:
@@ -117,7 +117,7 @@ class EulerPoseCollocationFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE const &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor4", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };
@@ -127,11 +127,11 @@ class EulerPoseCollocationFactor
  * pose of current and next time steps
  */
 class TrapezoidalPoseCollocationFactor
-    : public gtsam::NoiseModelFactor5<gtsam::Pose3, gtsam::Pose3,
+    : public gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3,
                                       gtsam::Vector6, gtsam::Vector6, double> {
  private:
   using This = TrapezoidalPoseCollocationFactor;
-  using Base = gtsam::NoiseModelFactor5<gtsam::Pose3, gtsam::Pose3,
+  using Base = gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3,
                                         gtsam::Vector6, gtsam::Vector6, double>;
 
  public:
@@ -201,7 +201,7 @@ class TrapezoidalPoseCollocationFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE const &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor5", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };
@@ -211,11 +211,11 @@ class TrapezoidalPoseCollocationFactor
  * poses of current and next time steps with fixed dt.
  */
 class FixTimeTrapezoidalPoseCollocationFactor
-    : public gtsam::NoiseModelFactor4<gtsam::Pose3, gtsam::Pose3,
+    : public gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3,
                                       gtsam::Vector6, gtsam::Vector6> {
  private:
   using This = FixTimeTrapezoidalPoseCollocationFactor;
-  using Base = gtsam::NoiseModelFactor4<gtsam::Pose3, gtsam::Pose3,
+  using Base = gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3,
                                         gtsam::Vector6, gtsam::Vector6>;
   double dt_;
 
@@ -282,7 +282,7 @@ class FixTimeTrapezoidalPoseCollocationFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE const &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor5", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };
@@ -292,11 +292,11 @@ class FixTimeTrapezoidalPoseCollocationFactor
  * of current and next time steps
  */
 class EulerTwistCollocationFactor
-    : public gtsam::NoiseModelFactor4<gtsam::Vector6, gtsam::Vector6,
+    : public gtsam::NoiseModelFactorN<gtsam::Vector6, gtsam::Vector6,
                                       gtsam::Vector6, double> {
  private:
   using This = EulerTwistCollocationFactor;
-  using Base = gtsam::NoiseModelFactor4<gtsam::Vector6, gtsam::Vector6,
+  using Base = gtsam::NoiseModelFactorN<gtsam::Vector6, gtsam::Vector6,
                                         gtsam::Vector6, double>;
 
  public:
@@ -359,7 +359,7 @@ class EulerTwistCollocationFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE const &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor4", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };
@@ -369,11 +369,11 @@ class EulerTwistCollocationFactor
  * twist of current and next time steps
  */
 class TrapezoidalTwistCollocationFactor
-    : public gtsam::NoiseModelFactor5<gtsam::Vector6, gtsam::Vector6,
+    : public gtsam::NoiseModelFactorN<gtsam::Vector6, gtsam::Vector6,
                                       gtsam::Vector6, gtsam::Vector6, double> {
  private:
   using This = TrapezoidalTwistCollocationFactor;
-  using Base = gtsam::NoiseModelFactor5<gtsam::Vector6, gtsam::Vector6,
+  using Base = gtsam::NoiseModelFactorN<gtsam::Vector6, gtsam::Vector6,
                                         gtsam::Vector6, gtsam::Vector6, double>;
 
  public:
@@ -444,7 +444,7 @@ class TrapezoidalTwistCollocationFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE const &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor5", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };
@@ -454,11 +454,11 @@ class TrapezoidalTwistCollocationFactor
  * between link twist of current and next time steps
  */
 class FixTimeTrapezoidalTwistCollocationFactor
-    : public gtsam::NoiseModelFactor4<gtsam::Vector6, gtsam::Vector6,
+    : public gtsam::NoiseModelFactorN<gtsam::Vector6, gtsam::Vector6,
                                       gtsam::Vector6, gtsam::Vector6> {
  private:
   using This = FixTimeTrapezoidalTwistCollocationFactor;
-  using Base = gtsam::NoiseModelFactor4<gtsam::Vector6, gtsam::Vector6,
+  using Base = gtsam::NoiseModelFactorN<gtsam::Vector6, gtsam::Vector6,
                                         gtsam::Vector6, gtsam::Vector6>;
   double dt_;
 
@@ -526,7 +526,7 @@ class FixTimeTrapezoidalTwistCollocationFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE const &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor4", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/factors/ContactDynamicsFrictionConeFactor.h
+++ b/gtdynamics/factors/ContactDynamicsFrictionConeFactor.h
@@ -31,10 +31,10 @@ namespace gtdynamics {
  * that the linear contact force lies within a friction cone.
  */
 class ContactDynamicsFrictionConeFactor
-    : public gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Vector6> {
+    : public gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Vector6> {
  private:
   using This = ContactDynamicsFrictionConeFactor;
-  using Base = gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Vector6>;
+  using Base = gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Vector6>;
 
   int up_axis_;  // Which axis is up (assuming flat ground)? {0: x, 1: y, 2: z}.
   double mu_prime_;  // static friction coefficient squared.
@@ -161,7 +161,7 @@ class ContactDynamicsFrictionConeFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE const &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/factors/ContactDynamicsMomentFactor.h
+++ b/gtdynamics/factors/ContactDynamicsMomentFactor.h
@@ -97,7 +97,7 @@ class ContactDynamicsMomentFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {  // NOLINT
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/factors/ContactEqualityFactor.h
+++ b/gtdynamics/factors/ContactEqualityFactor.h
@@ -31,10 +31,10 @@ namespace gtdynamics {
  * between contact points on the same link at two different time steps.
  */
 class ContactEqualityFactor
-    : public gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Pose3> {
+    : public gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3> {
  private:
   using This = ContactEqualityFactor;
-  using Base = gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Pose3>;
+  using Base = gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3>;
 
   /// The point on the link at which to enforce equality.
   PointOnLink point_on_link_;

--- a/gtdynamics/factors/ContactHeightFactor.h
+++ b/gtdynamics/factors/ContactHeightFactor.h
@@ -94,7 +94,7 @@ class ContactHeightFactor : public gtsam::ExpressionFactor<double> {
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {  // NOLINT
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/factors/ContactKinematicsAccelFactor.h
+++ b/gtdynamics/factors/ContactKinematicsAccelFactor.h
@@ -92,7 +92,7 @@ class ContactKinematicsAccelFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {  // NOLINT
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor3", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/factors/ContactKinematicsTwistFactor.h
+++ b/gtdynamics/factors/ContactKinematicsTwistFactor.h
@@ -91,7 +91,7 @@ class ContactKinematicsTwistFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {  // NOLINT
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor3", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/factors/ContactPointFactor.h
+++ b/gtdynamics/factors/ContactPointFactor.h
@@ -32,10 +32,10 @@ namespace gtdynamics {
  * contact.
  */
 class ContactPointFactor
-    : public gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Point3> {
+    : public gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Point3> {
  private:
   using This = ContactPointFactor;
-  using Base = gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Point3>;
+  using Base = gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Point3>;
 
   // The contact point in the link's CoM frame.
   gtsam::Point3 contact_in_com_;
@@ -122,10 +122,10 @@ class ContactPointFactor
  * This factor is useful for implementing flat foot constraints.
  */
 class ContactPoseFactor
-    : public gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Pose3> {
+    : public gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3> {
  private:
   using This = ContactPoseFactor;
-  using Base = gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Pose3>;
+  using Base = gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3>;
 
   // The contact point reference frame in the link's CoM frame.
   gtsam::Pose3 comTcontact_;
@@ -213,10 +213,10 @@ class ContactPoseFactor
 };
 
 /** Contact Point Factor with a static contact point. */
-class FixedContactPointFactor : public gtsam::NoiseModelFactor1<gtsam::Pose3> {
+class FixedContactPointFactor : public gtsam::NoiseModelFactorN<gtsam::Pose3> {
  private:
   using This = FixedContactPointFactor;
-  using Base = gtsam::NoiseModelFactor1<gtsam::Pose3>;
+  using Base = gtsam::NoiseModelFactorN<gtsam::Pose3>;
 
   // The contact point in the link's CoM frame.
   gtsam::Point3 contact_in_world_;

--- a/gtdynamics/factors/JointLimitFactor.h
+++ b/gtdynamics/factors/JointLimitFactor.h
@@ -30,10 +30,10 @@ namespace gtdynamics {
  * JointLimitFactor is a class which enforces joint angle value
  * to be within specified limits.
  */
-class JointLimitFactor : public gtsam::NoiseModelFactor1<double> {
+class JointLimitFactor : public gtsam::NoiseModelFactorN<double> {
  private:
   using This = JointLimitFactor;
-  using Base = gtsam::NoiseModelFactor1<double>;
+  using Base = gtsam::NoiseModelFactorN<double>;
   double low_, high_;
 
  public:
@@ -100,7 +100,7 @@ class JointLimitFactor : public gtsam::NoiseModelFactor1<double> {
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {  // NOLINT
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
     ar &low_;
     ar &high_;
   }

--- a/gtdynamics/factors/JointMeasurementFactor.h
+++ b/gtdynamics/factors/JointMeasurementFactor.h
@@ -24,10 +24,10 @@ namespace gtdynamics {
  * the joint coordinate as a measurement.
  */
 class JointMeasurementFactor
-    : public gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Pose3> {
+    : public gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3> {
  private:
   using This = JointMeasurementFactor;
-  using Base = gtsam::NoiseModelFactor2<gtsam::Pose3, gtsam::Pose3>;
+  using Base = gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3>;
 
   JointConstSharedPtr joint_;
   double measured_joint_coordinate_;

--- a/gtdynamics/factors/MinTorqueFactor.h
+++ b/gtdynamics/factors/MinTorqueFactor.h
@@ -23,10 +23,10 @@
 namespace gtdynamics {
 
 /// MinTorqueFactor is a unary factor which minimizes torque.
-class MinTorqueFactor : public gtsam::NoiseModelFactor1<double> {
+class MinTorqueFactor : public gtsam::NoiseModelFactorN<double> {
  private:
   using This = MinTorqueFactor;
-  using Base = gtsam::NoiseModelFactor1<double>;
+  using Base = gtsam::NoiseModelFactorN<double>;
 
  public:
   /**
@@ -77,7 +77,7 @@ class MinTorqueFactor : public gtsam::NoiseModelFactor1<double> {
   template <class ARCHIVE>
   void serialize(ARCHIVE const &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/factors/PointGoalFactor.h
+++ b/gtdynamics/factors/PointGoalFactor.h
@@ -76,7 +76,7 @@ class PointGoalFactor : public gtsam::ExpressionFactor<gtsam::Vector3> {
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {  // NOLINT
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/factors/PreintegratedContactFactors.h
+++ b/gtdynamics/factors/PreintegratedContactFactors.h
@@ -88,11 +88,11 @@ class PreintegratedPointContactMeasurements {
  * Hartley18icra.
  */
 class PreintegratedPointContactFactor
-    : public gtsam::NoiseModelFactor4<gtsam::Pose3, gtsam::Pose3, gtsam::Pose3,
+    : public gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3, gtsam::Pose3,
                                       gtsam::Pose3> {
  private:
   using This = PreintegratedPointContactFactor;
-  using Base = gtsam::NoiseModelFactor4<gtsam::Pose3, gtsam::Pose3,
+  using Base = gtsam::NoiseModelFactorN<gtsam::Pose3, gtsam::Pose3,
                                         gtsam::Pose3, gtsam::Pose3>;
 
  public:
@@ -192,7 +192,7 @@ class PreintegratedPointContactFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {  // NOLINT
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor4", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/jumpingrobot/factors/PneumaticActuatorFactors.h
+++ b/gtdynamics/jumpingrobot/factors/PneumaticActuatorFactors.h
@@ -26,10 +26,10 @@ namespace gtdynamics {
 /** ForceBalanceFactor is a three-way nonlinear factor which characterize
  * the relationship between pressure, contraction length and force */
 class ForceBalanceFactor
-    : public gtsam::NoiseModelFactor3<double, double, double> {
+    : public gtsam::NoiseModelFactorN<double, double, double> {
  private:
   typedef ForceBalanceFactor This;
-  typedef gtsam::NoiseModelFactor3<double, double, double> Base;
+  typedef gtsam::NoiseModelFactorN<double, double, double> Base;
   double k_, r_, q_rest_;
   bool positive_;
   gtsam::Matrix H_delta_x_, H_q_, H_f_;
@@ -100,7 +100,7 @@ class ForceBalanceFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor3", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };
@@ -108,10 +108,10 @@ class ForceBalanceFactor
 /** JointTorqueFactor is a three-way nonlinear factor which characterize
  * the relationship between pressure, contraction length and force */
 class JointTorqueFactor
-    : public gtsam::NoiseModelFactor4<double, double, double, double> {
+    : public gtsam::NoiseModelFactorN<double, double, double, double> {
  private:
   typedef JointTorqueFactor This;
-  typedef gtsam::NoiseModelFactor4<double, double, double, double> Base;
+  typedef gtsam::NoiseModelFactorN<double, double, double, double> Base;
   double q_limit_, ka_, r_, b_;
   bool positive_;
   gtsam::Matrix H_v_, H_f_, H_torque_;
@@ -199,7 +199,7 @@ class JointTorqueFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor4", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };
@@ -207,10 +207,10 @@ class JointTorqueFactor
 /** SmoothActuatorFactor fits a smooth relationship between pressure,
  * contraction length and force */
 class SmoothActuatorFactor
-    : public gtsam::NoiseModelFactor3<double, double, double> {
+    : public gtsam::NoiseModelFactorN<double, double, double> {
  private:
   typedef SmoothActuatorFactor This;
-  typedef gtsam::NoiseModelFactor3<double, double, double> Base;
+  typedef gtsam::NoiseModelFactorN<double, double, double> Base;
   const gtsam::Vector5 x0_coeffs_ =
       (gtsam::Vector(5) << 3.05583930e+00, 7.58361626e-02, -4.91579771e-04,
        1.42792618e-06, -1.54817477e-09)
@@ -338,10 +338,10 @@ class SmoothActuatorFactor
 /** ClippingActuatorFactor (deprecated) fits a non-smooth relationship between
  * pressure, contraction length and force, and use clipping for force < 0 */
 class ClippingActuatorFactor
-    : public gtsam::NoiseModelFactor3<double, double, double> {
+    : public gtsam::NoiseModelFactorN<double, double, double> {
  private:
   typedef ClippingActuatorFactor This;
-  typedef gtsam::NoiseModelFactor3<double, double, double> Base;
+  typedef gtsam::NoiseModelFactorN<double, double, double> Base;
   std::vector<double> coeffs_{-17.39,    1.11,       2.22,   -0.9486,
                               -0.4481,   -0.0003159, 0.1745, 0.01601,
                               0.0001081, -7.703e-07};
@@ -484,17 +484,17 @@ class ClippingActuatorFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor3", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };
 
 /** ActuatorVolumeFactor characterize the relationship between actuator volume
  * and contraction length */
-class ActuatorVolumeFactor : public gtsam::NoiseModelFactor2<double, double> {
+class ActuatorVolumeFactor : public gtsam::NoiseModelFactorN<double, double> {
  private:
   typedef ActuatorVolumeFactor This;
-  typedef gtsam::NoiseModelFactor2<double, double> Base;
+  typedef gtsam::NoiseModelFactorN<double, double> Base;
   gtsam::Vector4 c_ = gtsam::Vector4(4.243e-5, 3.141e-5, -3.251e-6, 1.28e-7);
   double D_, L_;
 
@@ -553,7 +553,7 @@ class ActuatorVolumeFactor : public gtsam::NoiseModelFactor2<double, double> {
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };

--- a/gtdynamics/jumpingrobot/factors/PneumaticFactors.h
+++ b/gtdynamics/jumpingrobot/factors/PneumaticFactors.h
@@ -26,10 +26,10 @@
 namespace gtdynamics {
 
 /** GasLawFactor: P*V=Rs*T */
-class GasLawFactor : public gtsam::NoiseModelFactor3<double, double, double> {
+class GasLawFactor : public gtsam::NoiseModelFactorN<double, double, double> {
  private:
   typedef GasLawFactor This;
-  typedef gtsam::NoiseModelFactor3<double, double, double> Base;
+  typedef gtsam::NoiseModelFactorN<double, double, double> Base;
   double c_;
 
  public:
@@ -77,17 +77,17 @@ class GasLawFactor : public gtsam::NoiseModelFactor3<double, double, double> {
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor3", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };
 
 /** MassFlowRateFactor: compute mdot from pressures*/
 class MassFlowRateFactor
-    : public gtsam::NoiseModelFactor3<double, double, double> {
+    : public gtsam::NoiseModelFactorN<double, double, double> {
  private:
   typedef MassFlowRateFactor This;
-  typedef gtsam::NoiseModelFactor3<double, double, double> Base;
+  typedef gtsam::NoiseModelFactorN<double, double, double> Base;
   double D_, L_, mu_, epsilon_, k_;
   double term1_, term2_, c1_, coeff_;
 
@@ -175,7 +175,7 @@ class MassFlowRateFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor3", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };
@@ -192,10 +192,10 @@ double sigmoid(double x, gtsam::OptionalMatrixType H_x = nullptr) {
 
 /** ValveControlFactor: compute true mdot based on valve open/close time. */
 class ValveControlFactor
-    : public gtsam::NoiseModelFactor5<double, double, double, double, double> {
+    : public gtsam::NoiseModelFactorN<double, double, double, double, double> {
  private:
   typedef ValveControlFactor This;
-  typedef gtsam::NoiseModelFactor5<double, double, double, double, double> Base;
+  typedef gtsam::NoiseModelFactorN<double, double, double, double, double> Base;
   double ct_inv_;
 
  public:
@@ -273,7 +273,7 @@ class ValveControlFactor
   template <class ARCHIVE>
   void serialize(ARCHIVE &ar, const unsigned int version) {
     ar &boost::serialization::make_nvp(
-        "NoiseModelFactor5", boost::serialization::base_object<Base>(*this));
+        "NoiseModelFactorN", boost::serialization::base_object<Base>(*this));
   }
 #endif
 };


### PR DESCRIPTION
To be consistent with recent updates, upgrading the factors to use @gchenfc's new `NoiseModelFactorN` base class.