### PR TITLE
Fix inconsistent test results

### DIFF
--- a/gtdynamics/kinematics/Kinematics.h
+++ b/gtdynamics/kinematics/Kinematics.h
@@ -148,12 +148,12 @@ class Kinematics : public Optimizer {
    *
    * @param context Slice or Interval instance.
    * @param robot Robot specification from URDF/SDF.
-   * @param gaussian_noise time step to check (default 0.1).
+   * @param gaussian_noise noise (stddev) added to initial values (default 0.0).
    * @returns values with identity poses and zero joint angles.
    */
   template <class CONTEXT>
   gtsam::Values initialValues(const CONTEXT& context, const Robot& robot,
-                              double gaussian_noise = 0.1) const;
+                              double gaussian_noise = 0.0) const;
 
   /**
    * @fn Inverse kinematics given a set of contact goals.

--- a/gtdynamics/statics/Statics.h
+++ b/gtdynamics/statics/Statics.h
@@ -124,9 +124,11 @@ class Statics : public Kinematics {
    * @param slice Slice instance.
    * @param robot Robot specification from URDF/SDF.
    * @param configuration A known kinematics configuration.
+   * @param gaussian_noise noise (stddev) added to initial values (default 0.0).
    */
   gtsam::Values solve(const Slice& slice, const Robot& robot,
-                      const gtsam::Values& configuration) const;
+                      const gtsam::Values& configuration,
+                      double gaussian_noise = 0.0) const;
 
   /**
    * Solve for wrenches and kinematics configuration.

--- a/gtdynamics/statics/Statics.h
+++ b/gtdynamics/statics/Statics.h
@@ -114,9 +114,10 @@ class Statics : public Kinematics {
    * TODO(frank): if we inherit, should we have *everything below us?
    * @param slice Slice instance.
    * @param robot Robot specification from URDF/SDF.
+   * @param gaussian_noise noise (stddev) added to initial values (default 0.0).
    */
   gtsam::Values initialValues(const Slice& slice, const Robot& robot,
-                              double gaussian_noise = 1e-6) const;
+                              double gaussian_noise = 0.0) const;
 
   /**
    * Solve for wrenches given kinematics configuration.

--- a/gtdynamics/statics/StaticsSlice.cpp
+++ b/gtdynamics/statics/StaticsSlice.cpp
@@ -103,8 +103,8 @@ gtsam::Values Statics::initialValues(const Slice& slice, const Robot& robot,
   // Initialize wrenches and torques to 0.
   for (auto&& joint : robot.joints()) {
     int j = joint->id();
-    InsertWrench(&values, joint->parent()->id(), j, k, gtsam::Z_6x1);
-    InsertWrench(&values, joint->child()->id(), j, k, gtsam::Z_6x1);
+    InsertWrench(&values, joint->parent()->id(), j, k, sampler.sample());
+    InsertWrench(&values, joint->child()->id(), j, k, sampler.sample());
     InsertTorque(&values, j, k, 0.0);
   }
 

--- a/gtdynamics/statics/StaticsSlice.cpp
+++ b/gtdynamics/statics/StaticsSlice.cpp
@@ -112,10 +112,11 @@ gtsam::Values Statics::initialValues(const Slice& slice, const Robot& robot,
 }
 
 gtsam::Values Statics::solve(const Slice& slice, const Robot& robot,
-                             const gtsam::Values& configuration) const {
+                             const gtsam::Values& configuration,
+                             double gaussian_noise) const {
   auto graph = this->graph(slice, robot);
   gtsam::Values initial_values;
-  initial_values.insert(initialValues(slice, robot));
+  initial_values.insert(initialValues(slice, robot, gaussian_noise));
 
   // In this function we assume the kinematics is given, and we add priors to
   // the graph to enforce this. Would be much nicer with constant expressions.

--- a/tests/testStaticsSlice.cpp
+++ b/tests/testStaticsSlice.cpp
@@ -117,16 +117,13 @@ TEST(Statics, Quadruped) {
   EXPECT_LONGS_EQUAL(37, graph.size());
 
   // Test initialization
-  auto values = statics.initialValues(slice, robot);
+  auto values = statics.initialValues(slice, robot, 0.0);
   EXPECT_LONGS_EQUAL(36, values.size());
 
   // Solve for wrenches, with known kinematics
   auto result = statics.solve(slice, robot, ik_solution);
   EXPECT_LONGS_EQUAL(61, result.size());
-  // TODO(Varun) Issue #233
-  // Regression
-  result.print("", GTDKeyFormatter);
-  // EXPECT_DOUBLES_EQUAL(0.0670426, Torque(result, 0, k), 1e-5);
+  EXPECT_DOUBLES_EQUAL(0.151803, Torque(result, 0, k), 1e-5);
 
   // Optimize kinematics while minimizing torque
   auto minimal = statics.minimizeTorques(slice, robot);

--- a/tests/testStaticsSlice.cpp
+++ b/tests/testStaticsSlice.cpp
@@ -123,7 +123,7 @@ TEST(Statics, Quadruped) {
   // Solve for wrenches, with known kinematics
   auto result = statics.solve(slice, robot, ik_solution);
   EXPECT_LONGS_EQUAL(61, result.size());
-  EXPECT_DOUBLES_EQUAL(0.151803, Torque(result, 0, k), 1e-5);
+  EXPECT_DOUBLES_EQUAL(0.054764, Torque(result, 0, k), 1e-5);
 
   // Optimize kinematics while minimizing torque
   auto minimal = statics.minimizeTorques(slice, robot);


### PR DESCRIPTION
Fixes #233.

The issue was that `Statics::solve` was calling `initialValues(slice, robot)` with a default gaussian noise parameter of 0.1. This is neither a functional style and is machine dependent due to the PRNG.

I added `gaussian_noise` as an extra parameter, and set all the `gaussian_noise` defaults to be a more sensible 0.0. The user is free to update them if desired.