### PR TITLE
Update CMake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 enable_testing()
 project(gtdynamics
         LANGUAGES CXX C

--- a/examples/cmake_project_example/CMakeLists.txt
+++ b/examples/cmake_project_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example C CXX)
 
 # gtsam

--- a/examples/example_a1_walking/CMakeLists.txt
+++ b/examples/example_a1_walking/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example_a1_walking C CXX)
 
 # Build Executables

--- a/examples/example_cart_pole_trajectory_optimization/CMakeLists.txt
+++ b/examples/example_cart_pole_trajectory_optimization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example_cart_pole_trajectory_optimization C CXX)
 
 # Build Executable

--- a/examples/example_constraint_manifold/CMakeLists.txt
+++ b/examples/example_constraint_manifold/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example_constraint_manifold C CXX)
 
 # Build Executable

--- a/examples/example_forward_dynamics/CMakeLists.txt
+++ b/examples/example_forward_dynamics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example_forward_dynamics C CXX)
 
 # Build Executable

--- a/examples/example_full_kinodynamic_balancing/CMakeLists.txt
+++ b/examples/example_full_kinodynamic_balancing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example_full_kinodynamic_balancing C CXX)
 
 # Build Executable

--- a/examples/example_full_kinodynamic_walking/CMakeLists.txt
+++ b/examples/example_full_kinodynamic_walking/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example_full_kinodynamic_walking C CXX)
 
 # Build Executables

--- a/examples/example_inverted_pendulum_trajectory_optimization/CMakeLists.txt
+++ b/examples/example_inverted_pendulum_trajectory_optimization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example_inverted_pendulum_trajectory_optimization C CXX)
 
 # Build Executable

--- a/examples/example_quadruped_mp/CMakeLists.txt
+++ b/examples/example_quadruped_mp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example_quadruped_mp C CXX)
 
 # Build Executable

--- a/examples/example_spider_walking/CMakeLists.txt
+++ b/examples/example_spider_walking/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(example_spider_walking C CXX)
 
 # Build Executables


### PR DESCRIPTION
CMake is throwing the warning:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

This PR updates all the CMake files to have the minimum version as 3.5 to fix any potential deprecations as well as maintain the largest generality.