### PR TITLE
Fix Memory Leak

### DIFF
--- a/tests/make_joint.h
+++ b/tests/make_joint.h
@@ -17,8 +17,16 @@
 #include <gtdynamics/universal_robot/Link.h>
 
 namespace gtdynamics {
-/// Create a joint with given rest transform cMp and screw-axis in child frame.
-JointConstSharedPtr make_joint(gtsam::Pose3 cMp, gtsam::Vector6 cScrewAxis) {
+/**
+ * Create a joint with given rest transform cMp and screw-axis in child frame.
+ *
+ * We return both the joint and its connected links so that
+ * the link pointers are alive in the test.
+ * This will be true in a Robot object since it holds
+ * both the joint and link pointers.
+ */
+std::pair<JointConstSharedPtr, std::vector<LinkSharedPtr>> make_joint(
+    gtsam::Pose3 cMp, gtsam::Vector6 cScrewAxis) {
   // create links
   std::string name = "l1";
   double mass = 100;
@@ -26,9 +34,8 @@ JointConstSharedPtr make_joint(gtsam::Pose3 cMp, gtsam::Vector6 cScrewAxis) {
   gtsam::Pose3 bMcom;
   gtsam::Pose3 bMl;
 
-  auto l1 = std::make_shared<Link>(Link(1, name, mass, inertia, bMcom, bMl));
-  auto l2 =
-      std::make_shared<Link>(Link(2, name, mass, inertia, cMp.inverse(), bMl));
+  auto l1 = std::make_shared<Link>(1, name, mass, inertia, bMcom, bMl);
+  auto l2 = std::make_shared<Link>(2, name, mass, inertia, cMp.inverse(), bMl);
 
   // create joint
   JointParams joint_params;
@@ -40,7 +47,11 @@ JointConstSharedPtr make_joint(gtsam::Pose3 cMp, gtsam::Vector6 cScrewAxis) {
   gtsam::Pose3 jMc = bMj.inverse() * l2->bMcom();
   gtsam::Vector6 jScrewAxis = jMc.AdjointMap() * cScrewAxis;
 
-  return std::make_shared<const HelicalJoint>(1, "j1", bMj, l1, l2, jScrewAxis,
+  auto joint = std::make_shared<HelicalJoint>(1, "j1", bMj, l1, l2, jScrewAxis,
                                               joint_params);
+  l1->addJoint(joint);
+  l2->addJoint(joint);
+  std::vector<LinkSharedPtr> links{l1, l2};
+  return {joint, links};
 }
 }  // namespace gtdynamics

--- a/tests/testPoseFactor.cpp
+++ b/tests/testPoseFactor.cpp
@@ -49,7 +49,8 @@ TEST(PoseFactor, error) {
   Pose3 cMp = Pose3(Rot3(), Point3(-2, 0, 0));
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
-  auto joint = make_joint(cMp, screw_axis);
+  auto joint_and_links = make_joint(cMp, screw_axis);
+  auto joint = joint_and_links.first;
 
   // Create factor
   auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
@@ -77,7 +78,8 @@ TEST(PoseFactor, breaking) {
   Pose3 cMp = Pose3(Rot3(), Point3(-2, 0, 0));
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
-  auto joint = make_joint(cMp, screw_axis);
+  auto joint_and_links = make_joint(cMp, screw_axis);
+  auto joint = joint_and_links.first;
   auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
                            example::cost_model, joint);
 
@@ -111,7 +113,8 @@ TEST(PoseFactor, breaking_rr) {
 
   Vector6 screw_axis = (Vector6() << 1, 0, 0, 0, -1, 0).finished();
   Pose3 cMp = j1->relativePoseOf(l1, 0.0);
-  auto joint = make_joint(cMp, screw_axis);
+  auto joint_and_links = make_joint(cMp, screw_axis);
+  auto joint = joint_and_links.first;
   auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
                            example::cost_model, joint);
 
@@ -129,7 +132,8 @@ TEST(PoseFactor, nonzero_rest) {
   Pose3 cMp = Pose3(Rot3::Rx(1), Point3(-2, 0, 0));
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
-  auto joint = make_joint(cMp, screw_axis);
+  auto joint_and_links = make_joint(cMp, screw_axis);
+  auto joint = joint_and_links.first;
   auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
                            example::cost_model, joint);
 

--- a/tests/testPoseFactor.cpp
+++ b/tests/testPoseFactor.cpp
@@ -49,8 +49,7 @@ TEST(PoseFactor, error) {
   Pose3 cMp = Pose3(Rot3(), Point3(-2, 0, 0));
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
-  auto joint_and_links = make_joint(cMp, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(cMp, screw_axis);
 
   // Create factor
   auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
@@ -78,8 +77,7 @@ TEST(PoseFactor, breaking) {
   Pose3 cMp = Pose3(Rot3(), Point3(-2, 0, 0));
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
-  auto joint_and_links = make_joint(cMp, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(cMp, screw_axis);
   auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
                            example::cost_model, joint);
 
@@ -113,8 +111,7 @@ TEST(PoseFactor, breaking_rr) {
 
   Vector6 screw_axis = (Vector6() << 1, 0, 0, 0, -1, 0).finished();
   Pose3 cMp = j1->relativePoseOf(l1, 0.0);
-  auto joint_and_links = make_joint(cMp, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(cMp, screw_axis);
   auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
                            example::cost_model, joint);
 
@@ -132,8 +129,7 @@ TEST(PoseFactor, nonzero_rest) {
   Pose3 cMp = Pose3(Rot3::Rx(1), Point3(-2, 0, 0));
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
-  auto joint_and_links = make_joint(cMp, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(cMp, screw_axis);
   auto factor = PoseFactor(example::wTp_key, example::wTc_key, example::q_key,
                            example::cost_model, joint);
 

--- a/tests/testTorqueFactor.cpp
+++ b/tests/testTorqueFactor.cpp
@@ -38,7 +38,8 @@ TEST(TorqueFactor, error) {
   gtsam::Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
 
-  auto joint = make_joint(kMj, screw_axis);
+  auto joint_and_links = make_joint(kMj, screw_axis);
+  auto joint = joint_and_links.first;
 
   // Create factor.
   auto cost_model = gtsam::noiseModel::Gaussian::Covariance(gtsam::I_1x1);

--- a/tests/testTorqueFactor.cpp
+++ b/tests/testTorqueFactor.cpp
@@ -38,8 +38,7 @@ TEST(TorqueFactor, error) {
   gtsam::Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
 
-  auto joint_and_links = make_joint(kMj, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(kMj, screw_axis);
 
   // Create factor.
   auto cost_model = gtsam::noiseModel::Gaussian::Covariance(gtsam::I_1x1);

--- a/tests/testTwistAccelFactor.cpp
+++ b/tests/testTwistAccelFactor.cpp
@@ -50,7 +50,8 @@ TEST(TwistAccelFactor, error) {
   gtsam::Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
 
-  auto joint = make_joint(cMp, screw_axis);
+  auto joint_and_links = make_joint(cMp, screw_axis);
+  auto joint = joint_and_links.first;
 
   // create factor
   auto factor = TwistAccelFactor(example::cost_model, joint, 0);
@@ -85,7 +86,8 @@ TEST(TwistAccelFactor, error_1) {
   gtsam::Pose3 cMp = gtsam::Pose3(gtsam::Rot3(), gtsam::Point3(-1, 0, 0));
   gtsam::Vector6 screw_axis = (gtsam::Vector(6) << 0, 0, 1, 0, 1, 0).finished();
 
-  auto joint = make_joint(cMp, screw_axis);
+  auto joint_and_links = make_joint(cMp, screw_axis);
+  auto joint = joint_and_links.first;
 
   auto factor = TwistAccelFactor(example::cost_model, joint, 0);
   double q = 0, qVel = 0, qAccel = -9.8;

--- a/tests/testTwistAccelFactor.cpp
+++ b/tests/testTwistAccelFactor.cpp
@@ -50,8 +50,7 @@ TEST(TwistAccelFactor, error) {
   gtsam::Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
 
-  auto joint_and_links = make_joint(cMp, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(cMp, screw_axis);
 
   // create factor
   auto factor = TwistAccelFactor(example::cost_model, joint, 0);
@@ -86,8 +85,7 @@ TEST(TwistAccelFactor, error_1) {
   gtsam::Pose3 cMp = gtsam::Pose3(gtsam::Rot3(), gtsam::Point3(-1, 0, 0));
   gtsam::Vector6 screw_axis = (gtsam::Vector(6) << 0, 0, 1, 0, 1, 0).finished();
 
-  auto joint_and_links = make_joint(cMp, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(cMp, screw_axis);
 
   auto factor = TwistAccelFactor(example::cost_model, joint, 0);
   double q = 0, qVel = 0, qAccel = -9.8;

--- a/tests/testTwistFactor.cpp
+++ b/tests/testTwistFactor.cpp
@@ -44,7 +44,8 @@ TEST(TwistFactor, error) {
   gtsam::Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
 
-  auto joint = make_joint(cMp, screw_axis);
+  auto joint_and_links = make_joint(cMp, screw_axis);
+  auto joint = joint_and_links.first;
 
   auto factor = TwistFactor(example::cost_model, joint, 0);
   double q = M_PI / 4, qVel = 10;

--- a/tests/testTwistFactor.cpp
+++ b/tests/testTwistFactor.cpp
@@ -44,8 +44,7 @@ TEST(TwistFactor, error) {
   gtsam::Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
 
-  auto joint_and_links = make_joint(cMp, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(cMp, screw_axis);
 
   auto factor = TwistFactor(example::cost_model, joint, 0);
   double q = M_PI / 4, qVel = 10;

--- a/tests/testWrenchEquivalenceFactor.cpp
+++ b/tests/testWrenchEquivalenceFactor.cpp
@@ -52,7 +52,8 @@ TEST(WrenchEquivalenceFactor, error_1) {
   Pose3 kMj = Pose3(Rot3(), Point3(-2, 0, 0));
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
-  auto joint = make_joint(kMj, screw_axis);
+  auto joint_and_links = make_joint(kMj, screw_axis);
+  auto joint = joint_and_links.first;
   auto factor = WrenchEquivalenceFactor(example::cost_model, joint, 777);
 
   // Check evaluateError.
@@ -79,7 +80,8 @@ TEST(WrenchEquivalenceFactor, error_2) {
   Pose3 kMj = Pose3(Rot3(), Point3(-2, 0, 0));
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
-  auto joint = make_joint(kMj, screw_axis);
+  auto joint_and_links = make_joint(kMj, screw_axis);
+  auto joint = joint_and_links.first;
   auto factor = WrenchEquivalenceFactor(example::cost_model, joint, 777);
 
   // Check evaluateError.
@@ -107,7 +109,8 @@ TEST(WrenchEquivalenceFactor, error_3) {
   Pose3 kMj = Pose3(Rot3(), Point3(0, 0, -2));
   Vector6 screw_axis;
   screw_axis << 1, 0, 0, 0, -1, 0;
-  auto joint = make_joint(kMj, screw_axis);
+  auto joint_and_links = make_joint(kMj, screw_axis);
+  auto joint = joint_and_links.first;
   auto factor = WrenchEquivalenceFactor(example::cost_model, joint, 777);
 
   // Check evaluateError.

--- a/tests/testWrenchEquivalenceFactor.cpp
+++ b/tests/testWrenchEquivalenceFactor.cpp
@@ -52,8 +52,7 @@ TEST(WrenchEquivalenceFactor, error_1) {
   Pose3 kMj = Pose3(Rot3(), Point3(-2, 0, 0));
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
-  auto joint_and_links = make_joint(kMj, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(kMj, screw_axis);
   auto factor = WrenchEquivalenceFactor(example::cost_model, joint, 777);
 
   // Check evaluateError.
@@ -80,8 +79,7 @@ TEST(WrenchEquivalenceFactor, error_2) {
   Pose3 kMj = Pose3(Rot3(), Point3(-2, 0, 0));
   Vector6 screw_axis;
   screw_axis << 0, 0, 1, 0, 1, 0;
-  auto joint_and_links = make_joint(kMj, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(kMj, screw_axis);
   auto factor = WrenchEquivalenceFactor(example::cost_model, joint, 777);
 
   // Check evaluateError.
@@ -109,8 +107,7 @@ TEST(WrenchEquivalenceFactor, error_3) {
   Pose3 kMj = Pose3(Rot3(), Point3(0, 0, -2));
   Vector6 screw_axis;
   screw_axis << 1, 0, 0, 0, -1, 0;
-  auto joint_and_links = make_joint(kMj, screw_axis);
-  auto joint = joint_and_links.first;
+  auto [joint, links] = make_joint(kMj, screw_axis);
   auto factor = WrenchEquivalenceFactor(example::cost_model, joint, 777);
 
   // Check evaluateError.

--- a/tests/testWrenchPlanarFactor.cpp
+++ b/tests/testWrenchPlanarFactor.cpp
@@ -35,8 +35,7 @@ gtsam::noiseModel::Gaussian::shared_ptr cost_model =
     gtsam::noiseModel::Gaussian::Covariance(gtsam::I_3x3);
 const DynamicsSymbol wrench_key = WrenchKey(2, 1, 777);
 gtsam::Pose3 kMj;  // doesn't matter
-auto joint_and_links = make_joint(kMj, gtsam::Z_6x1);
-auto joint = joint_and_links.first;
+auto [joint, links] = make_joint(kMj, gtsam::Z_6x1);
 }  // namespace example
 
 // Test wrench planar factor for x-axis

--- a/tests/testWrenchPlanarFactor.cpp
+++ b/tests/testWrenchPlanarFactor.cpp
@@ -35,7 +35,8 @@ gtsam::noiseModel::Gaussian::shared_ptr cost_model =
     gtsam::noiseModel::Gaussian::Covariance(gtsam::I_3x3);
 const DynamicsSymbol wrench_key = WrenchKey(2, 1, 777);
 gtsam::Pose3 kMj;  // doesn't matter
-auto joint = make_joint(kMj, gtsam::Z_6x1);
+auto joint_and_links = make_joint(kMj, gtsam::Z_6x1);
+auto joint = joint_and_links.first;
 }  // namespace example
 
 // Test wrench planar factor for x-axis


### PR DESCRIPTION
I ran `leaks` on the `testForwardKinematics` executable and I got the following memory leak reported.

```
>> leaks --atExit -- ./testForwardKinematicsFactor
testForwardKinematicsFactor(1381) MallocStackLogging: could not tag MSL-related memory as no_footprint, so those pages will be included in process footprint - (null)
testForwardKinematicsFactor(1381) MallocStackLogging: recording malloc and VM allocation stacks using lite mode
There were no test failures
Process:         testForwardKinematicsFactor [1381]
Path:            /Users/USER/*/testForwardKinematicsFactor
Load Address:    0x102778000
Identifier:      testForwardKinematicsFactor
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [1380]

Date/Time:       2024-10-22 09:50:43.803 -0400
Launch Time:     2024-10-22 09:50:42.962 -0400
OS Version:      macOS 14.6.1 (23G93)
Report Version:  7
Analysis Tool:   /Applications/Xcode.app/Contents/Developer/usr/bin/leaks
Analysis Tool Version:  Xcode 16.0 (16A242d)

Physical footprint:         10.2M
Physical footprint (peak):  28.1M
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 1381: 263 nodes malloced for 44 KB
Process 1381: 13 leaks for 4928 total leaked bytes.

STACK OF 1 INSTANCE OF 'ROOT CYCLE: <std::__shared_ptr_emplace<gtdynamics::Link>>':
21  dyld                                  0x18976eef4 start + 1868
20  dyld                                  0x189770010 dyld4::prepare(dyld4::APIs&, dyld3::MachOAnalyzer const*) + 3156
19  dyld                                  0x1897a9e3c dyld4::APIs::runAllInitializersForMain() + 464
18  dyld                                  0x189786b78 dyld4::Loader::runInitializersBottomUpPlusUpwardLinks(dyld4::RuntimeState&) const + 420
17  dyld                                  0x18978a698 dyld4::Loader::runInitializersBottomUpPlusUpwardLinks(dyld4::RuntimeState&) const::$_1::operator()() const + 116
16  dyld                                  0x189786984 dyld4::Loader::runInitializersBottomUp(dyld4::RuntimeState&, dyld3::Array<dyld4::Loader const*>&) const + 220
15  dyld                                  0x18978cbc0 dyld4::JustInTimeLoader::runInitializers(dyld4::RuntimeState&) const + 36
14  dyld                                  0x18978653c dyld4::Loader::findAndRunAllInitializers(dyld4::RuntimeState&) const + 564
13  dyld                                  0x1897c8880 dyld3::MachOAnalyzer::forEachInitializer(Diagnostics&, dyld3::MachOAnalyzer::VMAddrConverter const&, void (unsigned int) block_pointer, void const*) const + 516
12  dyld                                  0x1897bb394 dyld3::MachOFile::forEachSection(void (dyld3::MachOFile::SectionInfo const&, bool, bool&) block_pointer) const + 192
11  dyld                                  0x18976b2fc dyld3::MachOFile::forEachLoadCommand(Diagnostics&, void (load_command const*, bool&) block_pointer) const + 300
10  dyld                                  0x1897bc400 invocation function for block in dyld3::MachOFile::forEachSection(void (dyld3::MachOFile::SectionInfo const&, bool, bool&) block_pointer) const + 496
9   dyld                                  0x1897c8d6c invocation function for block in dyld3::MachOAnalyzer::forEachInitializer(Diagnostics&, dyld3::MachOAnalyzer::VMAddrConverter const&, void (unsigned int) block_pointer, void const*) const + 340
8   dyld                                  0x18978a608 invocation function for block in dyld4::Loader::findAndRunAllInitializers(dyld4::RuntimeState&) const::$_0::operator()() const + 168
7   testForwardKinematicsFactor           0x102789198 _GLOBAL__sub_I_testForwardKinematicsFactor.cpp + 640
6   testForwardKinematicsFactor           0x102780a9c simple_rr::getRobot() + 156
5   libgtdynamics.dylib                   0x102e36ec8 gtdynamics::CreateRobotFromFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool) + 716
4   libgtdynamics.dylib                   0x102e3731c gtdynamics::ExtractRobotFromSdf(sdf::v12::Model const&) + 128
3   libgtdynamics.dylib                   0x102e3655c gtdynamics::LinkFromSdf(unsigned char, sdf::v12::Link const&) + 408
2   libgtdynamics.dylib                   0x102e415a4 std::__1::shared_ptr<gtdynamics::Link> std::__1::allocate_shared[abi:ne180100]<gtdynamics::Link, std::__1::allocator<gtdynamics::Link>, unsigned char&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, double, Eigen::Matrix<double, 3, 3, 0, 3, 3>&, gtsam::Pose3 const&, gtsam::Pose3 const&, void>(std::__1::allocator<gtdynamics::Link> const&, unsigned char&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&, double&&, Eigen::Matrix<double, 3, 3, 0, 3, 3>&, gtsam::Pose3 const&, gtsam::Pose3 const&) + 64
1   libc++abi.dylib                       0x189ab2bd4 operator new(unsigned long) + 32
0   libsystem_malloc.dylib                0x189933a68 _malloc_zone_malloc_instrumented_or_legacy + 148
====
    8 (3.00K) ROOT CYCLE: <std::__shared_ptr_emplace<gtdynamics::Link> 0x13f7040f0> [624]
       CYCLE BACK TO <std::__shared_ptr_emplace<gtdynamics::Link> 0x13f7040f0> [624]
       7 (2.39K) ROOT CYCLE: <malloc in std::shared_ptr<gtsam::ConstVarFactor>* std::vector<std::shared_ptr<gtsam::ConstVarFactor>>::__push_back_slow_path<std::shared_ptr<gtsam::ConstVarFactor> const&>(std::shared_ptr<gtsam::ConstVarFactor> const&) 0x13f704bb0> [48]
          3 (1.17K) ROOT CYCLE: <std::__shared_ptr_emplace<gtdynamics::RevoluteJoint> 0x13f7046b0> [544]
             CYCLE BACK TO <std::__shared_ptr_emplace<gtdynamics::Link> 0x13f7040f0> [624]
             2 (656 bytes) ROOT CYCLE: <std::__shared_ptr_emplace<gtdynamics::Link> 0x142806f80> [624]
                1 (32 bytes) ROOT CYCLE: <malloc in std::shared_ptr<gtsam::ConstVarFactor>* std::vector<std::shared_ptr<gtsam::ConstVarFactor>>::__push_back_slow_path<std::shared_ptr<gtsam::ConstVarFactor> const&>(std::shared_ptr<gtsam::ConstVarFactor> const&) 0x1428074b0> [32]
          3 (1.17K) ROOT CYCLE: <std::__shared_ptr_emplace<gtdynamics::RevoluteJoint> 0x13f704940> [544]
             CYCLE BACK TO <std::__shared_ptr_emplace<gtdynamics::Link> 0x13f7040f0> [624]
             2 (656 bytes) ROOT CYCLE: <std::__shared_ptr_emplace<gtdynamics::Link> 0x13f704360> [624]
                1 (32 bytes) ROOT CYCLE: <malloc in std::shared_ptr<gtsam::ConstVarFactor>* std::vector<std::shared_ptr<gtsam::ConstVarFactor>>::__push_back_slow_path<std::shared_ptr<gtsam::ConstVarFactor> const&>(std::shared_ptr<gtsam::ConstVarFactor> const&) 0x13f704920> [32]

STACK OF 1 INSTANCE OF 'ROOT CYCLE: <malloc in std::shared_ptr<gtsam::ConstVarFactor>* std::vector<std::shared_ptr<gtsam::ConstVarFactor>>::__push_back_slow_path<std::shared_ptr<gtsam::ConstVarFactor> const&>(std::shared_ptr<gtsam::ConstVarFactor> const&)>':
8   dyld                                  0x18976f154 start + 2476
7   testForwardKinematicsFactor           0x102783a34 main + 28
6   testForwardKinematicsFactor           0x102789b48 TestRegistry::run(TestResult&) + 140
5   testForwardKinematicsFactor           0x10278304c ForwardKinematicsFactorArbitraryTimeTest::run(TestResult&) + 156
4   libgtdynamics.dylib                   0x102e36e68 gtdynamics::CreateRobotFromFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool) + 620
3   libgtdynamics.dylib                   0x102e37648 gtdynamics::ExtractRobotFromSdf(sdf::v12::Model const&) + 940
2   libgtdynamics.dylib                   0x102e385b8 std::__1::shared_ptr<gtsam::ConstVarFactor>* std::__1::vector<std::__1::shared_ptr<gtsam::ConstVarFactor>, std::__1::allocator<std::__1::shared_ptr<gtsam::ConstVarFactor>>>::__push_back_slow_path<std::__1::shared_ptr<gtsam::ConstVarFactor> const&>(std::__1::shared_ptr<gtsam::ConstVarFactor> const&) + 108
1   libc++abi.dylib                       0x189ab2bd4 operator new(unsigned long) + 32
0   libsystem_malloc.dylib                0x189933a68 _malloc_zone_malloc_instrumented_or_legacy + 148
====
    5 (1.81K) ROOT CYCLE: <malloc in std::shared_ptr<gtsam::ConstVarFactor>* std::vector<std::shared_ptr<gtsam::ConstVarFactor>>::__push_back_slow_path<std::shared_ptr<gtsam::ConstVarFactor> const&>(std::shared_ptr<gtsam::ConstVarFactor> const&) 0x13f728cb0> [32]
       4 (1.78K) ROOT CYCLE: <std::__shared_ptr_emplace<gtdynamics::RevoluteJoint> 0x142516a80> [544]
          2 (656 bytes) ROOT CYCLE: <std::__shared_ptr_emplace<gtdynamics::Link> 0x1425164c0> [624]
             1 (32 bytes) ROOT CYCLE: <malloc in std::shared_ptr<gtsam::ConstVarFactor>* std::vector<std::shared_ptr<gtsam::ConstVarFactor>>::__push_back_slow_path<std::shared_ptr<gtsam::ConstVarFactor> const&>(std::shared_ptr<gtsam::ConstVarFactor> const&) 0x13f729df0> [32]
          1 (624 bytes) ROOT CYCLE: <std::__shared_ptr_emplace<gtdynamics::Link> 0x142516730> [624]
             CYCLE BACK TO <malloc in std::shared_ptr<gtsam::ConstVarFactor>* std::vector<std::shared_ptr<gtsam::ConstVarFactor>>::__push_back_slow_path<std::shared_ptr<gtsam::ConstVarFactor> const&>(std::shared_ptr<gtsam::ConstVarFactor> const&) 0x13f728cb0> [32]



Binary Images:
       0x102778000 -        0x10278bfff +testForwardKinematicsFactor (0) <DB6C85A3-E8F1-3F9D-9A00-EDC670F255EA> /Users/*/testForwardKinematicsFactor
       0x102bf4000 -        0x102bf7fff +libboost_system-mt.dylib (0) <21A16FE8-4B85-372A-976E-F23295800E4D> /opt/homebrew/*/libboost_system-mt.dylib
       0x102c08000 -        0x102c0bffb  libLeaksAtExit.dylib (64565.58.2) <90C61A85-289F-324E-8444-CC5235D63E96> /usr/lib/libLeaksAtExit.dylib
       0x102c1c000 -        0x102c1ffff +libboost_date_time-mt.dylib (0) <F7EEACD2-3B63-3235-9998-CFFD0BEC4C00> /opt/homebrew/*/libboost_date_time-mt.dylib
       0x102c34000 -        0x102c37fff +libboost_atomic-mt.dylib (0) <E1B959B9-E9B9-3787-867A-0200BE8D51D0> /opt/homebrew/*/libboost_atomic-mt.dylib
       0x102c50000 -        0x102c67fff +libboost_filesystem-mt.dylib (0) <6DCFABDE-C703-31E1-AA60-59F89B6A828B> /opt/homebrew/*/libboost_filesystem-mt.dylib
       0x102c94000 -        0x102cb7fff +libboost_serialization-mt.dylib (0) <2C4F328C-0D72-3292-9986-0BD70306D958> /opt/homebrew/*/libboost_serialization-mt.dylib
       0x102d0c000 -        0x102d0fff7 +libboost_timer-mt.dylib (0) <5116DE9A-0C76-35BF-A26F-6EF32CDBCE64> /opt/homebrew/*/libboost_timer-mt.dylib
       0x102d20000 -        0x102d23fff +libignition-utils1.1.5.1.dylib (0) <0AF75DE0-BEC0-30B3-AB1E-7867060D0148> /opt/homebrew/*/libignition-utils1.1.5.1.dylib
       0x102d34000 -        0x102d3ffff +libboost_thread-mt.dylib (0) <32D58590-EEDA-3A58-BC42-362307339FA3> /opt/homebrew/*/libboost_thread-mt.dylib
       0x102d5c000 -        0x102d5ffff +libconsole_bridge.1.0.dylib (0) <22CEADFB-DD1A-3994-8648-589336674501> /opt/homebrew/*/libconsole_bridge.1.0.dylib
       0x102d74000 -        0x102d77fff +libboost_chrono-mt.dylib (0) <FB5CB409-B0B1-3FD4-8B30-8511FE8E0423> /opt/homebrew/*/libboost_chrono-mt.dylib
       0x102d8c000 -        0x102d93fff +liburdfdom_sensor.3.0.dylib (0) <D3A28050-369D-3E20-83DF-CC266DE30921> /opt/homebrew/*/liburdfdom_sensor.3.0.dylib
       0x102da0000 -        0x102da7ffb +liburdfdom_model_state.3.0.dylib (0) <1BF7D86A-A480-3149-8D1A-5DE167E825D9> /opt/homebrew/*/liburdfdom_model_state.3.0.dylib
       0x102db4000 -        0x102dcfffb +libcephes-gtsam.1.0.0.dylib (0) <5BD9B6E7-93F5-3ED1-B054-347723359F71> /Users/*/libcephes-gtsam.1.0.0.dylib
       0x102ddc000 -        0x102de7ff3 +libtinyxml2.9.0.0.dylib (0) <2D7CBB13-5019-36FC-A216-207951A9CE30> /opt/homebrew/*/libtinyxml2.9.0.0.dylib
       0x102dfc000 -        0x102f0fff3 +libgtdynamics.dylib (0) <303300B6-F623-3A49-8A11-7319B2893CE3> /Users/*/libgtdynamics.dylib
       0x102fe0000 -        0x103017ff7 +libboost_regex-mt.dylib (0) <6946F778-9CE6-3319-9BB2-3A4EED8DABEF> /opt/homebrew/*/libboost_regex-mt.dylib
       0x103040000 -        0x10304bfff +libtbbmalloc.2.13.dylib (0) <DB9E4154-080D-3781-8187-C707CF552422> /opt/homebrew/*/libtbbmalloc.2.13.dylib
       0x1030a8000 -        0x1030dbfff +libignition-math6.6.15.0.dylib (0) <8A48967C-87F1-38B1-9F9A-D444E18D4152> /opt/homebrew/*/libignition-math6.6.15.0.dylib
       0x103110000 -        0x103127ff3 +libtbb.12.13.dylib (0) <FC848F76-EA6E-397D-8107-0E7CE3E28DC4> /opt/homebrew/*/libtbb.12.13.dylib
       0x103164000 -        0x103177fff +liburdfdom_model.3.0.dylib (0) <0F2AEDFD-8054-36D0-84DB-E352EF8EA57C> /opt/homebrew/*/liburdfdom_model.3.0.dylib
       0x103190000 -        0x1031a3ff3 +liburdfdom_world.3.0.dylib (0) <FBF99400-E4C0-386E-AAD7-C9DDB992B8E3> /opt/homebrew/*/liburdfdom_world.3.0.dylib
       0x1031bc000 -        0x1031c7ff3 +libtinyxml.dylib (0) <C4BE1B23-7ADD-354B-81B3-35722211C317> /opt/homebrew/*/libtinyxml.dylib
       0x103320000 -        0x103453ff7 +libicuuc.75.1.dylib (0) <3AF9E421-D6B8-3F57-877E-1B2DE15B71B2> /opt/homebrew/*/libicuuc.75.1.dylib
       0x103510000 -        0x10381ffff +libgtsam.4.3a0.dylib (0) <DB65AE8C-03D3-340D-8AFB-5B2D5588CF2E> /Users/*/libgtsam.4.3a0.dylib
       0x103a54000 -        0x103c57ffb +libsdformat12.12.7.2.dylib (0) <3150A738-5277-30A1-8945-89E42AF5A2C0> /opt/homebrew/*/libsdformat12.12.7.2.dylib
       0x103d18000 -        0x103ec7ff7 +libicui18n.75.1.dylib (0) <54E56A64-2DF9-319F-94EF-B338D16231EE> /opt/homebrew/*/libicui18n.75.1.dylib
       0x105aa8000 -        0x1077f7fff +libicudata.75.1.dylib (0) <EDBB7629-173E-3355-B1FF-EE3ADEA91612> /opt/homebrew/*/libicudata.75.1.dylib
       0x189718000 -        0x189768e0b  libobjc.A.dylib (912.7) <5C6386BD-F308-3370-BCE9-63D1A89DAB87> /usr/lib/libobjc.A.dylib
       0x189769000 -        0x1897f2507  dyld (1.0.0 - 1165.3) <F635824E-318B-3F0C-842C-C369737F2B68> /usr/lib/dyld
       0x1897f3000 -        0x1897f7ff8  libsystem_blocks.dylib (90) <6BC23DD4-94AC-3BB0-BC84-93E6D7813ACE> /usr/lib/system/libsystem_blocks.dylib
       0x1897f8000 -        0x189842fff  libxpc.dylib (2748.140.10) <987AF6AA-AB54-39CE-84CF-C6D2D1DC9464> /usr/lib/system/libxpc.dylib
       0x189843000 -        0x18985dfff  libsystem_trace.dylib (1510.140.4) <72852AF1-4BCC-326A-BE13-6C6F22A44E4A> /usr/lib/system/libsystem_trace.dylib
       0x18985e000 -        0x189907fcf  libcorecrypto.dylib (1638.140.6) <717EA919-DB53-3DDA-AFA1-D87BFD649A83> /usr/lib/system/libcorecrypto.dylib
       0x189908000 -        0x189944ff7  libsystem_malloc.dylib (521.120.7) <8A69A1AC-6D54-3B64-9860-CD0DB47473ED> /usr/lib/system/libsystem_malloc.dylib
       0x189945000 -        0x18998cfff  libdispatch.dylib (1477.100.9) <1A1CE00A-89CD-36BA-9678-5038AEDD0D8D> /usr/lib/system/libdispatch.dylib
       0x18998d000 -        0x18998ffff  libsystem_featureflags.dylib (86) <F9E56A3B-6350-3D8B-BEC6-6BC253B19355> /usr/lib/system/libsystem_featureflags.dylib
       0x189990000 -        0x189a0eff7  libsystem_c.dylib (1592.100.35) <D30F1830-93D0-3D0B-8CBA-9544E84BFD5B> /usr/lib/system/libsystem_c.dylib
       0x189a0f000 -        0x189a9bff7  libc++.1.dylib (1700.255.5) <AAA5636D-6F3F-3FA7-9F4A-CF966F0308FE> /usr/lib/libc++.1.dylib
       0x189a9c000 -        0x189ab7ffb  libc++abi.dylib (1700.255.5) <68E3EB36-B4BA-30E0-A240-31E942936D06> /usr/lib/libc++abi.dylib
       0x189ab8000 -        0x189af2ffb  libsystem_kernel.dylib (10063.141.2) <71FF45B8-F14E-3666-9E96-6CF58315B91D> /usr/lib/system/libsystem_kernel.dylib
       0x189af3000 -        0x189afffff  libsystem_pthread.dylib (519.120.4) <E03E8478-6F5C-3D21-A79A-58408F514000> /usr/lib/system/libsystem_pthread.dylib
       0x189b00000 -        0x189b25ff7  libdyld.dylib (1165.3) <C433509D-7CD3-3884-B24D-5D68B9B95627> /usr/lib/system/libdyld.dylib
       0x189b26000 -        0x189b2dfe7  libsystem_platform.dylib (316.100.10) <B4BF9F89-31D7-3742-8CE7-AB3554F9F525> /usr/lib/system/libsystem_platform.dylib
       0x189b2e000 -        0x189b5affb  libsystem_info.dylib (583.0.1) <827E8091-520E-3537-8E72-678CED1BAAAE> /usr/lib/system/libsystem_info.dylib
       0x18cf1e000 -        0x18cf28ff3  libsystem_darwin.dylib (1592.100.35) <4DD0C579-C2FC-37A7-B6D7-1BA7268DD8B3> /usr/lib/system/libsystem_darwin.dylib
       0x18d394000 -        0x18d3a4fff  libsystem_notify.dylib (317.120.2) <6902E910-4F75-32C7-BBF3-D46CD6743BFA> /usr/lib/system/libsystem_notify.dylib
       0x18f1ea000 -        0x18f204fff  libsystem_networkextension.dylib (1838.140.5.0.1) <9ADD8A04-8F8C-3916-A9ED-20F6947294BD> /usr/lib/system/libsystem_networkextension.dylib
       0x18f27d000 -        0x18f294ff7  libsystem_asl.dylib (398) <138939F9-52A2-35BF-A8E5-4B2154A3F1B0> /usr/lib/system/libsystem_asl.dylib
       0x190c6f000 -        0x190c77ff3  libsystem_symptoms.dylib (1871.140.6) <3E5E0270-E98C-303F-A566-624005886B88> /usr/lib/system/libsystem_symptoms.dylib
       0x193dfd000 -        0x193e27ffb  libsystem_containermanager.dylib (582.140.2) <230DEE13-0738-3710-A305-2D87D2522E52> /usr/lib/system/libsystem_containermanager.dylib
       0x194dc1000 -        0x194dc5fff  libsystem_configuration.dylib (1300.120.2) <4F21FA09-0224-337E-9843-10109C019B1E> /usr/lib/system/libsystem_configuration.dylib
       0x194dc6000 -        0x194dcbfff  libsystem_sandbox.dylib (2190.140.13) <DA843F8C-6155-3B7C-99B0-DEB74CF9F109> /usr/lib/system/libsystem_sandbox.dylib
       0x195be9000 -        0x195bebfff  libquarantine.dylib (172.140.2) <1F514E6F-7D94-356E-A5DC-6E8DCDD40846> /usr/lib/system/libquarantine.dylib
       0x1963a0000 -        0x1963a5fff  libsystem_coreservices.dylib (152.5.3) <CF38F1DD-9C1B-34D8-8C4D-DC5899486CD1> /usr/lib/system/libsystem_coreservices.dylib
       0x1966ce000 -        0x196704ff3  libsystem_m.dylib (3252.100.9) <0BE2E009-9F7F-331D-B4AC-F39136591F6F> /usr/lib/system/libsystem_m.dylib
       0x196709000 -        0x196710ffb  libmacho.dylib (1010.6) <BB441E41-3804-3949-B620-0B29D7975490> /usr/lib/system/libmacho.dylib
       0x196731000 -        0x19673eff7  libcommonCrypto.dylib (600028.100.1) <B0A2DDA7-420D-3DDE-9FE2-3AFDD2188F14> /usr/lib/system/libcommonCrypto.dylib
       0x19673f000 -        0x19674afff  libunwind.dylib (1700.242) <40A5125B-1225-337B-9D1A-968356D29580> /usr/lib/system/libunwind.dylib
       0x19674b000 -        0x196752fff  liboah.dylib (318.9) <749BB71D-B6F2-3C9D-A96D-65D22F7A42B3> /usr/lib/liboah.dylib
       0x196753000 -        0x19675cfff  libcopyfile.dylib (196.120.5) <3F3A181E-C6AB-3F09-BC74-37B8AC2BBE57> /usr/lib/system/libcopyfile.dylib
       0x19675d000 -        0x196760fff  libcompiler_rt.dylib (103.2) <D133BCC9-EFB7-3C69-83D2-A33BB6AFA430> /usr/lib/system/libcompiler_rt.dylib
       0x196761000 -        0x196765ffb  libsystem_collections.dylib (1592.100.35) <E08997D8-CC79-3A51-A3E0-B7706A78CC50> /usr/lib/system/libsystem_collections.dylib
       0x196766000 -        0x196769ffb  libsystem_secinit.dylib (147.140.2) <1F043FF2-1603-32F0-A8FB-DC6CBB118581> /usr/lib/system/libsystem_secinit.dylib
       0x19676a000 -        0x19676cffb  libremovefile.dylib (70.100.4) <01FAC88B-53F2-36C6-91EE-1EC62AC11CC8> /usr/lib/system/libremovefile.dylib
       0x19676d000 -        0x19676dffb  libkeymgr.dylib (31) <59B09DF8-56B7-3FAC-94D3-CC946797E98E> /usr/lib/system/libkeymgr.dylib
       0x19676e000 -        0x196776fff  libsystem_dnssd.dylib (2200.140.11) <4E11F9C6-8BD5-380C-A46F-7AB5DD6E91B6> /usr/lib/system/libsystem_dnssd.dylib
       0x196777000 -        0x19677cfff  libcache.dylib (93) <291EEBA0-190B-30E0-A7FF-1ED0CA3505B4> /usr/lib/system/libcache.dylib
       0x19677d000 -        0x19677efff  libSystem.B.dylib (1345.120.2) <2C0809B3-B3E0-3921-BB57-569E6984EC1A> /usr/lib/libSystem.B.dylib
       0x1af494000 -        0x1af49ffff  com.apple.MallocStackLogging (1.0 - 64565.70.2) <996FAAAE-AA80-3D57-BBE4-727436BAF450> /System/Library/PrivateFrameworks/MallocStackLogging.framework/Versions/A/MallocStackLogging
       0x251671000 -        0x251674fff  libsystem_darwindirectory.dylib (86.0.2) <815D7896-79A3-36C4-8008-DD672DA625C5> /usr/lib/system/libsystem_darwindirectory.dylib
       0x251675000 -        0x251678fff  libsystem_eligibility.dylib (47.140.3) <ADF6A9D2-C5C3-3A9C-9302-4618D9DFAD21> /usr/lib/system/libsystem_eligibility.dylib
       0x251679000 -        0x25167cffb  libsystem_sanitizers.dylib (8) <6BBDFCBC-D608-3318-BC22-2172E5258046> /usr/lib/system/libsystem_sanitizers.dylib
```

The issue here is that we have a reference cycle of shared pointers, one from `Joint` to `Link` and another one from `Link` to `Joint`. This can cause orphaned cycles to be leaked.

- https://stackoverflow.com/a/67356203/1236990
- https://en.cppreference.com/w/cpp/memory/weak_ptr

The fix for this is to use a `std::weak_ptr` which I have done for the `child_link_` and `parent_link_` in the `Joint` class.

After the updates, I get the following memory leak report:

```
leaks --atExit -- ./testForwardKinematicsFactor
testForwardKinematicsFactor(8235) MallocStackLogging: could not tag MSL-related memory as no_footprint, so those pages will be included in process footprint - (null)
testForwardKinematicsFactor(8235) MallocStackLogging: recording malloc and VM allocation stacks using lite mode
There were no test failures
Process:         testForwardKinematicsFactor [8235]
Path:            /Users/USER/*/testForwardKinematicsFactor
Load Address:    0x100cb4000
Identifier:      testForwardKinematicsFactor
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [8234]

Date/Time:       2024-10-22 09:58:38.896 -0400
Launch Time:     2024-10-22 09:58:38.086 -0400
OS Version:      macOS 14.6.1 (23G93)
Report Version:  7
Analysis Tool:   /Applications/Xcode.app/Contents/Developer/usr/bin/leaks
Analysis Tool Version:  Xcode 16.0 (16A242d)

Physical footprint:         10.8M
Physical footprint (peak):  28.4M
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 8235: 250 nodes malloced for 39 KB
Process 8235: 0 leaks for 0 total leaked bytes.
```