### PR TITLE
Added equality constraint to inverse kinematics

### DIFF
--- a/gtdynamics.i
+++ b/gtdynamics.i
@@ -369,10 +369,14 @@ class Kinematics {
                  gtdynamics::KinematicsParameters());
   gtsam::Values inverse(const gtdynamics::Slice &slice,
                         const gtdynamics::Robot &robot,
-                        const gtdynamics::ContactGoals &contact_goals);
+                        const gtdynamics::ContactGoals &contact_goals,
+                        bool contact_goals_as_constraints = true,
+                        const gtsam::Values &joint_targets = gtsam::Values());
   gtsam::Values inverse(const gtdynamics::Interval interval,
                         const gtdynamics::Robot &robot,
-                        const gtdynamics::ContactGoals &contact_goals);
+                        const gtdynamics::ContactGoals &contact_goals,
+                        bool contact_goals_as_constraints = true,
+                        const gtsam::Values &joint_targets = gtsam::Values());
   gtsam::Values
   interpolate(const gtdynamics::Interval &interval,
               const gtdynamics::Robot &robot,

--- a/gtdynamics/kinematics/Kinematics.h
+++ b/gtdynamics/kinematics/Kinematics.h
@@ -21,6 +21,7 @@
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/LevenbergMarquardtParams.h>
+#include <optional>
 
 namespace gtdynamics {
 
@@ -244,7 +245,8 @@ class Kinematics : public Optimizer {
   template <class CONTEXT>
   gtsam::NonlinearEqualityConstraints jointAngleConstraints(
       const CONTEXT& context, const Robot& robot,
-      const gtsam::Values& joint_targets) const;
+      const gtsam::Values& joint_targets,
+      const std::optional<double>& tolerance = {}) const;
 
   /**
    * @fn Create a pose prior for a given link for each given pose.
@@ -308,7 +310,8 @@ class Kinematics : public Optimizer {
   template <class CONTEXT>
   gtsam::Values inverse(const CONTEXT& context, const Robot& robot,
                         const ContactGoals& contact_goals,
-                        bool contact_goals_as_constraints = true) const;
+                        bool contact_goals_as_constraints = true,
+                        const gtsam::Values& joint_targets = gtsam::Values()) const;
 
   /**
    * @fn Inverse kinematics given a set of desired poses

--- a/gtdynamics/kinematics/KinematicsInterval.cpp
+++ b/gtdynamics/kinematics/KinematicsInterval.cpp
@@ -96,10 +96,12 @@ gtsam::NonlinearEqualityConstraints Kinematics::pointGoalConstraints<Interval>(
 template <>
 gtsam::NonlinearEqualityConstraints Kinematics::jointAngleConstraints<Interval>(
     const Interval& interval, const Robot& robot,
-    const gtsam::Values& joint_targets) const {
+    const gtsam::Values& joint_targets,
+    const std::optional<double>& tolerance) const {
   gtsam::NonlinearEqualityConstraints constraints;
   for (size_t k = interval.k_start; k <= interval.k_end; k++) {
-    auto slice_constraints = jointAngleConstraints(Slice(k), robot, joint_targets);
+    auto slice_constraints =
+        jointAngleConstraints(Slice(k), robot, joint_targets, tolerance);
     for (const auto& constraint : slice_constraints) {
       constraints.push_back(constraint);
     }
@@ -137,9 +139,10 @@ template <>
 Values Kinematics::inverse<Interval>(const Interval& interval,
                                      const Robot& robot,
                                      const ContactGoals& contact_goals,
-                                     bool contact_goals_as_constraints) const {
+                                     bool contact_goals_as_constraints,
+                                     const gtsam::Values& joint_targets) const {
   return collectValues(interval, [&](const Slice& slice) {
-    return inverse(slice, robot, contact_goals, contact_goals_as_constraints);
+    return inverse(slice, robot, contact_goals, contact_goals_as_constraints, joint_targets);
   });
 }
 

--- a/gtdynamics/kinematics/KinematicsSlice.cpp
+++ b/gtdynamics/kinematics/KinematicsSlice.cpp
@@ -244,10 +244,12 @@ gtsam::NonlinearEqualityConstraints Kinematics::pointGoalConstraints<Slice>(
 template <>
 gtsam::NonlinearEqualityConstraints Kinematics::jointAngleConstraints<Slice>(
     const Slice& slice, const Robot& robot,
-    const gtsam::Values& joint_targets) const {
+    const gtsam::Values& joint_targets,
+    const std::optional<double>& tolerance) const {
   gtsam::NonlinearEqualityConstraints constraints;
 
-  const gtsam::Vector1 tolerance(p_.prior_q_cost_model->sigmas()(0));
+  // If the user sets a tolerance, use it (needed for joint angle equality constraints)
+  const gtsam::Vector1 tol(tolerance.value_or(p_.prior_q_cost_model->sigmas()(0)));
   for (auto&& joint : robot.joints()) {
     const gtsam::Key key = JointAngleKey(joint->id(), slice.k);
     if (!joint_targets.exists(key)) {
@@ -255,7 +257,7 @@ gtsam::NonlinearEqualityConstraints Kinematics::jointAngleConstraints<Slice>(
     }
     const gtsam::Double_ joint_angle_expr(key);
     constraints.emplace_shared<gtsam::ExpressionEqualityConstraint<double>>(
-        joint_angle_expr, joint_targets.at<double>(key), tolerance);
+        joint_angle_expr, joint_targets.at<double>(key), tol);
   }
 
   return constraints;
@@ -351,7 +353,8 @@ Values Kinematics::initialValues<Slice>(const Slice& slice, const Robot& robot,
 template <>
 Values Kinematics::inverse<Slice>(const Slice& slice, const Robot& robot,
                                   const ContactGoals& contact_goals,
-                                  bool contact_goals_as_constraints) const {
+                                  bool contact_goals_as_constraints,
+                                  const gtsam::Values& joint_targets) const {
   // Robot kinematics constraints
   auto constraints = this->constraints(slice, robot);
   NonlinearFactorGraph graph;
@@ -372,6 +375,10 @@ Values Kinematics::inverse<Slice>(const Slice& slice, const Robot& robot,
   // TODO(frank): allow pose prior as well.
   // graph.addPrior<gtsam::Pose3>(PoseKey(0, slice.k),
   // gtsam::Pose3(), nullptr);
+
+  // Add equality constraints for joint angles
+  auto locked = this->jointAngleConstraints(slice, robot, joint_targets, 1e-3);
+  for (const auto& c : locked) constraints.push_back(c);
 
   // TODO(frank): we should allow warm start when used in interval context.
   auto initial_values = initialValues(slice, robot);

--- a/gtdynamics/kinematics/KinematicsTrajectory.cpp
+++ b/gtdynamics/kinematics/KinematicsTrajectory.cpp
@@ -74,11 +74,12 @@ gtsam::NonlinearEqualityConstraints Kinematics::pointGoalConstraints<Trajectory>
 template <>
 gtsam::NonlinearEqualityConstraints Kinematics::jointAngleConstraints<Trajectory>(
     const Trajectory& trajectory, const Robot& robot,
-    const Values& joint_targets) const {
+    const Values& joint_targets,
+    const std::optional<double>& tolerance) const {
   gtsam::NonlinearEqualityConstraints constraints;
   for (auto&& phase : trajectory.phases()) {
     auto phase_constraints =
-        jointAngleConstraints<Interval>(phase, robot, joint_targets);
+        jointAngleConstraints<Interval>(phase, robot, joint_targets, tolerance);
     for (const auto& constraint : phase_constraints) {
       constraints.push_back(constraint);
     }
@@ -113,11 +114,12 @@ template <>
 Values Kinematics::inverse<Trajectory>(
     const Trajectory& trajectory, const Robot& robot,
     const ContactGoals& contact_goals,
-    bool contact_goals_as_constraints) const {
+    bool contact_goals_as_constraints,
+    const gtsam::Values& joint_targets) const {
   Values results;
   for (auto&& phase : trajectory.phases()) {
     results.insert(inverse<Interval>(phase, robot, contact_goals,
-                                     contact_goals_as_constraints));
+                                     contact_goals_as_constraints, joint_targets));
   }
   return results;
 }

--- a/gtdynamics/kinematics/tests/testKinematicsSlice.cpp
+++ b/gtdynamics/kinematics/tests/testKinematicsSlice.cpp
@@ -82,6 +82,24 @@ TEST(Slice, InverseKinematics) {
     EXPECT(goal.satisfied(result, k, tol));
   }
 }
+TEST(Slice, InverseKinematicsLockedJoints) {
+  // Load robot and establish contact/goal pairs
+  using namespace contact_goals_example;
+
+  // Instantiate kinematics algorithms
+  KinematicsParameters parameters;
+  parameters.method = OptimizationParameters::Method::AUGMENTED_LAGRANGIAN;
+  Kinematics kinematics(parameters);
+
+  // Lock the first joint to a chosen angle.
+  const auto joint_id = robot.joints()[0] -> id();
+  const double locked_angle = 0.3;
+  gtsam::Values joint_targets;
+  InsertJointAngle(&joint_targets, joint_id, k, locked_angle);
+  auto result = kinematics.inverse(kSlice, robot, contact_goals, false, joint_targets);
+  EXPECT_DOUBLES_EQUAL(locked_angle, result.at<double>(JointAngleKey(joint_id, k)), 1e-4);
+
+}
 
 gtsam::Values jointVectorToValues(const Robot& robot,
                                   const gtsam::Vector7& joints) {


### PR DESCRIPTION
-Adds a hard equality constraint that forces the optimizer to find joint angles such that one (or multiple) equal a set value.
-Wrote a unit test that validates this approach.

TODO: add the ability for soft inequality constraints to be directly applied to inverse kinematics (ex. make a certain joint angle fall within a range).