### PR TITLE
Fix Python dependency compatibility

### DIFF
--- a/python/templates/pyproject.toml.in
+++ b/python/templates/pyproject.toml.in
@@ -22,8 +22,8 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=2.0.0",
-    "gtsam>=4.2",
+    "numpy>=1.11.0",
+    "gtsam>=4.3a0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Why

GTDynamics currently requires `numpy>=2.0.0` while accepting `gtsam>=4.2`. Those constraints are unnecessarily restrictive and can also be internally inconsistent: GTSAM 4.2 wheels were constrained to NumPy 1.x, while current GTSAM 4.3 supports both NumPy 1.x and 2.x.

This change:

- relaxes the NumPy requirement to the same supported lower bound used by current GTSAM, `numpy>=1.11.0`;
- raises the GTSAM requirement to `gtsam>=4.3a0`, avoiding the older 4.2 wheel line that was pinned below NumPy 2.

This lets pip retain a compatible NumPy 1.x installation instead of reporting a false conflict or forcing an unnecessary NumPy 2 upgrade.

## Verification

- CMake configuration completed successfully.
- The native GTDynamics library compiled successfully.
- `pip install --dry-run .` resolved successfully with NumPy 1.26.4 and GTSAM 4.3a2.
- The Python test target could not start locally because the installed gtwrap is older than the latest GTDynamics wrapper template (`KeyError: 'declaration_module_def'`); this is unrelated to the dependency metadata change.

@kshaji3, could you please check out this branch locally and make sure the wrapper and test suite still work in your setup?
